### PR TITLE
feat: 회의 시 오디오 데이터 수신 및 저장 구조 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/jolupbisang/demo/application/meeting/dto/AudioMeta.java
+++ b/src/main/java/com/jolupbisang/demo/application/meeting/dto/AudioMeta.java
@@ -1,0 +1,13 @@
+package com.jolupbisang.demo.application.meeting.dto;
+
+import java.time.LocalDateTime;
+
+public record AudioMeta(
+        String type,
+        long userId,
+        long meetingId,
+        int chunkId,
+        LocalDateTime timestamp,
+        String encoding
+) {
+}

--- a/src/main/java/com/jolupbisang/demo/application/meeting/service/MeetingService.java
+++ b/src/main/java/com/jolupbisang/demo/application/meeting/service/MeetingService.java
@@ -1,5 +1,8 @@
 package com.jolupbisang.demo.application.meeting.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jolupbisang.demo.application.meeting.dto.AudioMeta;
 import com.jolupbisang.demo.application.meeting.dto.MeetingReq;
 import com.jolupbisang.demo.application.meeting.exception.MeetingErrorCode;
 import com.jolupbisang.demo.domain.meeting.Meeting;
@@ -7,6 +10,7 @@ import com.jolupbisang.demo.domain.meetingUser.MeetingUser;
 import com.jolupbisang.demo.domain.meetingUser.MeetingUserStatus;
 import com.jolupbisang.demo.domain.user.User;
 import com.jolupbisang.demo.global.exception.CustomException;
+import com.jolupbisang.demo.global.properties.MeetingProperties;
 import com.jolupbisang.demo.infrastructure.meeting.MeetingRepository;
 import com.jolupbisang.demo.infrastructure.meetingUser.MeetingUserRepository;
 import com.jolupbisang.demo.infrastructure.user.UserRepository;
@@ -14,7 +18,16 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.socket.BinaryMessage;
+import org.springframework.web.socket.WebSocketSession;
 
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 
 @Slf4j
@@ -25,6 +38,9 @@ public class MeetingService {
     private final UserRepository userRepository;
     private final MeetingRepository meetingRepository;
     private final MeetingUserRepository meetingUserRepository;
+
+    private final MeetingProperties meetingProperties;
+    private final ObjectMapper objectMapper;
 
     @Transactional
     public void createMeeting(MeetingReq meetingReq, Long userId) {
@@ -38,5 +54,54 @@ public class MeetingService {
         meetingUserRepository.save(new MeetingUser(meeting, leader, true, MeetingUserStatus.ACCEPTED));
         meetingUserRepository.saveAll(participants.stream().map(p ->
                 new MeetingUser(meeting, p, false, MeetingUserStatus.WAITING)).toList());
+    }
+
+    public void processAndSendAudioData(WebSocketSession session, BinaryMessage message) throws IOException {
+        ByteBuffer buffer = message.getPayload();
+        AudioMeta audioMeta = extractAudioMeta(buffer);
+        log.info("{}", audioMeta);
+        byte[] audioData = extractAudioData(buffer);
+        log.info("{}", audioData);
+        saveAudio(audioMeta, audioData);
+    }
+
+    private void saveAudio(AudioMeta audioMeta, byte[] audioData) throws IOException {
+        Path dirPath = Path.of(meetingProperties.getBaseDir(),
+                Long.toString(audioMeta.meetingId()),
+                Long.toString(audioMeta.userId()));
+        String filename = Integer.toString(audioMeta.chunkId());
+
+        if (!Files.exists(dirPath)) {
+            Files.createDirectories(dirPath);
+        }
+
+        File chunkFile = dirPath.resolve(filename).toFile();
+
+        try (FileOutputStream fos = new FileOutputStream(chunkFile)) {
+            fos.write(audioData);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private AudioMeta extractAudioMeta(ByteBuffer byteBuffer) {
+        int metaLength = byteBuffer.getInt();
+        byte[] metaData = new byte[metaLength];
+        byteBuffer.get(metaData);
+        String metaString = new String(metaData, StandardCharsets.UTF_8);
+
+        try {
+            return objectMapper.readValue(metaString, AudioMeta.class);
+        } catch (JsonProcessingException ex) {
+            log.error("Error parsing JSON: {}", ex.getMessage());
+            return null;
+        }
+    }
+
+    private byte[] extractAudioData(ByteBuffer byteBuffer) {
+        byte[] audioBytes = new byte[byteBuffer.remaining()];
+        byteBuffer.get(audioBytes);
+
+        return audioBytes;
     }
 }

--- a/src/main/java/com/jolupbisang/demo/global/config/SecurityConfig.java
+++ b/src/main/java/com/jolupbisang/demo/global/config/SecurityConfig.java
@@ -22,7 +22,8 @@ public class SecurityConfig {
     private static final String[] PUBLIC_ENDPOINTS = {
             "/swagger-resources/**", "/swagger-ui/**", "/webjars/**", "/api-docs/**",  //Swagger
             "/error", "/env",
-            "/api/auth/**"
+            "/api/auth/**",
+            "/ws/**"
     };
 
 

--- a/src/main/java/com/jolupbisang/demo/global/config/WebSocketConfig.java
+++ b/src/main/java/com/jolupbisang/demo/global/config/WebSocketConfig.java
@@ -1,0 +1,22 @@
+package com.jolupbisang.demo.global.config;
+
+import com.jolupbisang.demo.presentation.meeting.MeetingSocketHandler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.socket.config.annotation.EnableWebSocket;
+import org.springframework.web.socket.config.annotation.WebSocketConfigurer;
+import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry;
+
+@Configuration
+@EnableWebSocket
+@RequiredArgsConstructor
+public class WebSocketConfig implements WebSocketConfigurer {
+
+    private final MeetingSocketHandler meetingSocketHandler;
+
+    @Override
+    public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
+        registry.addHandler(meetingSocketHandler, "/ws/meeting")
+                .setAllowedOrigins("*");
+    }
+}

--- a/src/main/java/com/jolupbisang/demo/global/properties/MeetingProperties.java
+++ b/src/main/java/com/jolupbisang/demo/global/properties/MeetingProperties.java
@@ -1,0 +1,14 @@
+package com.jolupbisang.demo.global.properties;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties("meeting")
+@Getter
+@Setter
+public class MeetingProperties {
+    private String baseDir;
+}

--- a/src/main/java/com/jolupbisang/demo/presentation/meeting/MeetingSocketHandler.java
+++ b/src/main/java/com/jolupbisang/demo/presentation/meeting/MeetingSocketHandler.java
@@ -1,0 +1,35 @@
+package com.jolupbisang.demo.presentation.meeting;
+
+
+import com.jolupbisang.demo.application.meeting.service.MeetingService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.BinaryMessage;
+import org.springframework.web.socket.CloseStatus;
+import org.springframework.web.socket.WebSocketSession;
+import org.springframework.web.socket.handler.BinaryWebSocketHandler;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class MeetingSocketHandler extends BinaryWebSocketHandler {
+
+    private final MeetingService meetingService;
+
+    @Override
+    public void afterConnectionEstablished(WebSocketSession session) throws Exception {
+        log.info("WebSocket Connection Established: {}", session.getId());
+    }
+
+    @Override
+    protected void handleBinaryMessage(WebSocketSession session, BinaryMessage message) throws Exception {
+        log.info("핸들러 도착");
+        meetingService.processAndSendAudioData(session, message);
+    }
+
+    @Override
+    public void afterConnectionClosed(WebSocketSession session, CloseStatus status) throws Exception {
+        log.info("WebSocket Connection Closed: {} - Status: {}", session.getId(), status);
+    }
+}


### PR DESCRIPTION
## 개요
회의 시 오디오 데이터 수신 및 저장 구조 추가

## 구현 기능
- WebSocket 관련 설정
- 오디오 전송 프로토콜 정의 및 구현
- 바이너리 데이터 변환 및 저장 로직 추가 (wav 형태로 저장됨)

## 남아있는 개선사항
- 오디오 데이터가 8KB를 넘어갈 경우 오류가 나며 웹소켓이 끊김 -> 버퍼 크기 설정을 통해 개선 예정
- 오류에 대한 예외 처리가 안되어있음 - ExceptionInterceptor를 통해 개선 예정
- 웹 소켓 연결시 JWT를 통한 인증 과정(Interceptor)가 필요 -> 추가 예정