### PR TITLE
feat: 아젠다 추가 및 상태 변경 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,9 +39,32 @@ dependencies {
     //JWT
     implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6', 'io.jsonwebtoken:jjwt-jackson:0.12.6'
-    
+
+    //QueryDsl
+    implementation 'com.querydsl:querydsl-jpa:5.1.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:5.1.0:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
 tasks.named('test') {
     useJUnitPlatform()
+}
+
+// QueryDSL QClass 생성 경로 설정
+def querydslDir = "$buildDir/generated/querydsl"
+
+// QueryDSL QClass 생성을 위한 설정
+sourceSets {
+    main.java.srcDir querydslDir
+}
+
+// QueryDSL QClass 생성 태스크 설정
+tasks.withType(JavaCompile) {
+    options.getGeneratedSourceOutputDirectory().set(file(querydslDir))
+}
+
+// clean 태스크 실행 시 QClass 디렉토리도 삭제
+clean {
+    delete file(querydslDir)
 }

--- a/src/main/java/com/jolupbisang/demo/application/agenda/exception/AgendaErrorCode.java
+++ b/src/main/java/com/jolupbisang/demo/application/agenda/exception/AgendaErrorCode.java
@@ -1,0 +1,23 @@
+package com.jolupbisang.demo.application.agenda.exception;
+
+import com.jolupbisang.demo.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public enum AgendaErrorCode implements ErrorCode {
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "권한이 없는 사용자입니다.");
+
+    private final HttpStatus status;
+    private final String message;
+
+    @Override
+    public HttpStatus getStatus() {
+        return status;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/com/jolupbisang/demo/application/agenda/service/AgendaService.java
+++ b/src/main/java/com/jolupbisang/demo/application/agenda/service/AgendaService.java
@@ -1,0 +1,27 @@
+package com.jolupbisang.demo.application.agenda.service;
+
+import com.jolupbisang.demo.application.agenda.exception.AgendaErrorCode;
+import com.jolupbisang.demo.domain.agenda.Agenda;
+import com.jolupbisang.demo.global.exception.CustomException;
+import com.jolupbisang.demo.infrastructure.agenda.AgendaRepository;
+import com.jolupbisang.demo.infrastructure.meeting.MeetingRepository;
+import com.jolupbisang.demo.infrastructure.user.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AgendaService {
+    private final AgendaRepository agendaRepository;
+    private final UserRepository userRepository;
+    private final MeetingRepository meetingRepository;
+
+    @Transactional
+    public void changeAgendaStatus(Long agendaId, Long userId, boolean isCompleted) {
+        Agenda agenda = agendaRepository.findByAgendaIdAndUserId(agendaId, userId)
+                .orElseThrow(() -> new CustomException(AgendaErrorCode.UNAUTHORIZED));
+
+        agenda.setIsCompleted(isCompleted);
+    }
+}

--- a/src/main/java/com/jolupbisang/demo/application/meeting/dto/MeetingReq.java
+++ b/src/main/java/com/jolupbisang/demo/application/meeting/dto/MeetingReq.java
@@ -28,7 +28,10 @@ public record MeetingReq(
         Integer restInterval,
 
         @NotNull(message = "참여자 목록은 필수입니다.")
-        List<@Email(message = "참여자는 이메일 형식이어야 합니다.") String> participants
+        List<@Email(message = "참여자는 이메일 형식이어야 합니다.") String> participants,
+
+        @NotNull(message = "회의 안건 목록은 필수입니다.")
+        List<@NotBlank(message = "회의 안건은 1글자 이상이어야 합니다.") String> agendas
 ) {
     public Meeting toEntity() {
         return new Meeting(title, location, scheduledStartTime, targetTime, restInterval);

--- a/src/main/java/com/jolupbisang/demo/application/meeting/service/MeetingService.java
+++ b/src/main/java/com/jolupbisang/demo/application/meeting/service/MeetingService.java
@@ -5,12 +5,14 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jolupbisang.demo.application.meeting.dto.AudioMeta;
 import com.jolupbisang.demo.application.meeting.dto.MeetingReq;
 import com.jolupbisang.demo.application.meeting.exception.MeetingErrorCode;
+import com.jolupbisang.demo.domain.agenda.Agenda;
 import com.jolupbisang.demo.domain.meeting.Meeting;
 import com.jolupbisang.demo.domain.meetingUser.MeetingUser;
 import com.jolupbisang.demo.domain.meetingUser.MeetingUserStatus;
 import com.jolupbisang.demo.domain.user.User;
 import com.jolupbisang.demo.global.exception.CustomException;
 import com.jolupbisang.demo.global.properties.MeetingProperties;
+import com.jolupbisang.demo.infrastructure.agenda.AgendaRepository;
 import com.jolupbisang.demo.infrastructure.meeting.MeetingRepository;
 import com.jolupbisang.demo.infrastructure.meetingUser.MeetingUserRepository;
 import com.jolupbisang.demo.infrastructure.user.UserRepository;
@@ -38,6 +40,7 @@ public class MeetingService {
     private final UserRepository userRepository;
     private final MeetingRepository meetingRepository;
     private final MeetingUserRepository meetingUserRepository;
+    private final AgendaRepository agendaRepository;
 
     private final MeetingProperties meetingProperties;
     private final ObjectMapper objectMapper;
@@ -54,6 +57,9 @@ public class MeetingService {
         meetingUserRepository.save(new MeetingUser(meeting, leader, true, MeetingUserStatus.ACCEPTED));
         meetingUserRepository.saveAll(participants.stream().map(p ->
                 new MeetingUser(meeting, p, false, MeetingUserStatus.WAITING)).toList());
+
+        agendaRepository.saveAll(meetingReq.agendas().stream().map(agenda ->
+                new Agenda(meeting, agenda)).toList());
     }
 
     public void processAndSendAudioData(WebSocketSession session, BinaryMessage message) throws IOException {

--- a/src/main/java/com/jolupbisang/demo/domain/agenda/Agenda.java
+++ b/src/main/java/com/jolupbisang/demo/domain/agenda/Agenda.java
@@ -22,4 +22,10 @@ public class Agenda {
     private String content;
 
     private boolean isCompleted;
+
+    public Agenda(Meeting meeting, String content) {
+        this.meeting = meeting;
+        this.content = content;
+        this.isCompleted = false;
+    }
 }

--- a/src/main/java/com/jolupbisang/demo/domain/agenda/Agenda.java
+++ b/src/main/java/com/jolupbisang/demo/domain/agenda/Agenda.java
@@ -28,4 +28,8 @@ public class Agenda {
         this.content = content;
         this.isCompleted = false;
     }
+
+    public void setIsCompleted(boolean isCompleted) {
+        this.isCompleted = true;
+    }
 }

--- a/src/main/java/com/jolupbisang/demo/domain/meetingUser/MeetingUser.java
+++ b/src/main/java/com/jolupbisang/demo/domain/meetingUser/MeetingUser.java
@@ -36,8 +36,4 @@ public class MeetingUser {
         this.isHost = isHost;
         this.status = status;
     }
-
-
-    //서비스 두개를 합친 서비스
-    //서비스를 더 잘게 쪼갠 애들을 하나의 서비스가 사용
 }

--- a/src/main/java/com/jolupbisang/demo/global/config/QueryDslConfig.java
+++ b/src/main/java/com/jolupbisang/demo/global/config/QueryDslConfig.java
@@ -1,0 +1,19 @@
+package com.jolupbisang.demo.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/com/jolupbisang/demo/infrastructure/agenda/AgendaRepository.java
+++ b/src/main/java/com/jolupbisang/demo/infrastructure/agenda/AgendaRepository.java
@@ -3,5 +3,5 @@ package com.jolupbisang.demo.infrastructure.agenda;
 import com.jolupbisang.demo.domain.agenda.Agenda;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface AgendaRepository extends JpaRepository<Agenda, Long> {
+public interface AgendaRepository extends JpaRepository<Agenda, Long>, AgendaRepositoryCustom {
 }

--- a/src/main/java/com/jolupbisang/demo/infrastructure/agenda/AgendaRepositoryCustom.java
+++ b/src/main/java/com/jolupbisang/demo/infrastructure/agenda/AgendaRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.jolupbisang.demo.infrastructure.agenda;
+
+import com.jolupbisang.demo.domain.agenda.Agenda;
+
+import java.util.Optional;
+
+public interface AgendaRepositoryCustom {
+
+    Optional<Agenda> findByAgendaIdAndUserId(Long agendaId, Long userId);
+}

--- a/src/main/java/com/jolupbisang/demo/infrastructure/agenda/AgendaRepositoryImpl.java
+++ b/src/main/java/com/jolupbisang/demo/infrastructure/agenda/AgendaRepositoryImpl.java
@@ -1,0 +1,32 @@
+package com.jolupbisang.demo.infrastructure.agenda;
+
+import com.jolupbisang.demo.domain.agenda.Agenda;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Optional;
+
+import static com.jolupbisang.demo.domain.agenda.QAgenda.agenda;
+import static com.jolupbisang.demo.domain.meetingUser.QMeetingUser.meetingUser;
+
+@RequiredArgsConstructor
+public class AgendaRepositoryImpl implements AgendaRepositoryCustom {
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Optional<Agenda> findByAgendaIdAndUserId(Long agendaId, Long userId) {
+        return Optional.ofNullable(
+                queryFactory
+                        .selectFrom(agenda)
+                        .where(agenda.meeting.id.in(
+                                        JPAExpressions
+                                                .select(meetingUser.meeting.id)
+                                                .from(meetingUser)
+                                                .where(meetingUser.user.id.eq(userId))
+                                )
+                                .and(agenda.id.eq(agendaId)))
+                        .fetchOne()
+        );
+    }
+}

--- a/src/main/java/com/jolupbisang/demo/presentation/agenda/AgendaController.java
+++ b/src/main/java/com/jolupbisang/demo/presentation/agenda/AgendaController.java
@@ -1,0 +1,30 @@
+package com.jolupbisang.demo.presentation.agenda;
+
+import com.jolupbisang.demo.application.agenda.service.AgendaService;
+import com.jolupbisang.demo.infrastructure.auth.security.CustomUserDetails;
+import com.jolupbisang.demo.presentation.agenda.dto.AgendaStatusRequest;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/agendas")
+public class AgendaController {
+    private final AgendaService agendaService;
+
+    @PatchMapping("/{agendaId}")
+    public ResponseEntity<?> changeAgendaStatus(@RequestBody @Valid AgendaStatusRequest agendaStatusRequest,
+                                                @PathVariable("agendaId") Long agendaId,
+                                                @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        agendaService.changeAgendaStatus(
+                agendaId,
+                customUserDetails.getUserId(),
+                agendaStatusRequest.isCompleted());
+
+        return ResponseEntity.status(HttpStatus.ACCEPTED).body("회의 안건 상태 변경 성공");
+    }
+}

--- a/src/main/java/com/jolupbisang/demo/presentation/agenda/AgendaController.java
+++ b/src/main/java/com/jolupbisang/demo/presentation/agenda/AgendaController.java
@@ -2,7 +2,7 @@ package com.jolupbisang.demo.presentation.agenda;
 
 import com.jolupbisang.demo.application.agenda.service.AgendaService;
 import com.jolupbisang.demo.infrastructure.auth.security.CustomUserDetails;
-import com.jolupbisang.demo.presentation.agenda.dto.AgendaStatusRequest;
+import com.jolupbisang.demo.presentation.agenda.dto.AgendaStatusReq;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -17,13 +17,13 @@ public class AgendaController {
     private final AgendaService agendaService;
 
     @PatchMapping("/{agendaId}")
-    public ResponseEntity<?> changeAgendaStatus(@RequestBody @Valid AgendaStatusRequest agendaStatusRequest,
+    public ResponseEntity<?> changeAgendaStatus(@RequestBody @Valid AgendaStatusReq agendaStatusReq,
                                                 @PathVariable("agendaId") Long agendaId,
                                                 @AuthenticationPrincipal CustomUserDetails customUserDetails) {
         agendaService.changeAgendaStatus(
                 agendaId,
                 customUserDetails.getUserId(),
-                agendaStatusRequest.isCompleted());
+                agendaStatusReq.isCompleted());
 
         return ResponseEntity.status(HttpStatus.ACCEPTED).body("회의 안건 상태 변경 성공");
     }

--- a/src/main/java/com/jolupbisang/demo/presentation/agenda/dto/AgendaStatusReq.java
+++ b/src/main/java/com/jolupbisang/demo/presentation/agenda/dto/AgendaStatusReq.java
@@ -4,6 +4,6 @@ import jakarta.validation.constraints.NotNull;
 
 public record AgendaStatusReq(
         @NotNull(message = "완료 상태는 null일 수 없습니다.")
-        boolean isCompleted
+        Boolean isCompleted
 ) {
 }

--- a/src/main/java/com/jolupbisang/demo/presentation/agenda/dto/AgendaStatusReq.java
+++ b/src/main/java/com/jolupbisang/demo/presentation/agenda/dto/AgendaStatusReq.java
@@ -2,8 +2,8 @@ package com.jolupbisang.demo.presentation.agenda.dto;
 
 import jakarta.validation.constraints.NotNull;
 
-public record AgendaStatusRequest(
-        @NotNull(message = "isCompleted는 null일 수 없습니다.")
+public record AgendaStatusReq(
+        @NotNull(message = "완료 상태는 null일 수 없습니다.")
         boolean isCompleted
 ) {
 }

--- a/src/main/java/com/jolupbisang/demo/presentation/agenda/dto/AgendaStatusRequest.java
+++ b/src/main/java/com/jolupbisang/demo/presentation/agenda/dto/AgendaStatusRequest.java
@@ -1,0 +1,9 @@
+package com.jolupbisang.demo.presentation.agenda.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record AgendaStatusRequest(
+        @NotNull(message = "isCompleted는 null일 수 없습니다.")
+        boolean isCompleted
+) {
+}


### PR DESCRIPTION
## 개요
아젠다 추가 및 상태 변경 기능 추가   
queryDsl 의존성 추가

## 구현기능
- Meeting 생성시 Agenda도 받도록 추가
- Agenda 완료 상태 변경 기능 추가

## 테스트
### Meeting 생성시 Agenda도 받도록 추가
1. 회의 생성 성공   

<img width="1047" alt="스크린샷 2025-04-04 오후 7 52 37" src="https://github.com/user-attachments/assets/41919639-a890-44fd-b2ce-0d084f953389" />

2. dto 검증 실패   

<img width="1055" alt="스크린샷 2025-04-04 오후 7 52 30" src="https://github.com/user-attachments/assets/5e4f17af-a059-4c68-bd8d-92b5ecf705b4" />
   
3. dto 배열 요소 검증 실패   

<img width="1063" alt="스크린샷 2025-04-04 오후 7 52 19" src="https://github.com/user-attachments/assets/fa645a2e-1ac7-45d9-899f-5731161267ba" />

### Agenda 완료 상태 변경 기능 추가
1. Agenda(회의 안건) 상태 변경 성공

<img width="1021" alt="0시43분3초 am 2025-04-06 오전 12 45 27" src="https://github.com/user-attachments/assets/ad71101e-c9c1-466d-9c1c-50f2d060105a" />

2. Agenda 상태 변경 권한 없음 또는 Agenda 없음

<img width="1023" alt="0시43분3초 am 2025-04-06 오전 12 45 01" src="https://github.com/user-attachments/assets/3ed6e704-5e58-4091-b198-a4754f4b4b96" />

3. dto 검증 실패

<img width="1014" alt="0시43분3초 am 2025-04-06 오전 1 01 31" src="https://github.com/user-attachments/assets/29b9a0a4-ecdb-4e7c-918d-b550ace43e80" />
