### PR TITLE
feat: 회의 단건 조회 및 월별 목록 조회 기능 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ bin/
 out/
 !**/src/main/**/out/
 !**/src/test/**/out/
+.DS_Store
 
 ### NetBeans ###
 /nbproject/private/

--- a/src/main/java/com/jolupbisang/demo/application/common/validator/MeetingAccessValidator.java
+++ b/src/main/java/com/jolupbisang/demo/application/common/validator/MeetingAccessValidator.java
@@ -31,4 +31,12 @@ public class MeetingAccessValidator {
             throw new CustomException(MeetingAccessErrorCode.NOT_PARTICIPANT);
         }
     }
+
+    public void validateUserParticipating(Long meetingId, Long userId) {
+        boolean isParticipant = meetingUserRepository.existsByMeetingIdAndUserIdAndStatusIn(meetingId, userId, MeetingUserStatus.ACCEPTED);
+
+        if (!isParticipant) {
+            throw new CustomException(MeetingAccessErrorCode.NOT_PARTICIPANT);
+        }
+    }
 }

--- a/src/main/java/com/jolupbisang/demo/application/meeting/dto/MeetingDetailSummary.java
+++ b/src/main/java/com/jolupbisang/demo/application/meeting/dto/MeetingDetailSummary.java
@@ -1,0 +1,20 @@
+package com.jolupbisang.demo.application.meeting.dto;
+
+import com.jolupbisang.demo.domain.meeting.Meeting;
+
+public record MeetingDetailSummary(
+        Long id,
+        String title,
+        String location,
+        String scheduledStartTime,
+        String status
+) {
+    public static MeetingDetailSummary fromEntity(Meeting meeting) {
+        return new MeetingDetailSummary(
+                meeting.getId(),
+                meeting.getTitle(),
+                meeting.getLocation(),
+                meeting.getScheduledStartTime().toString(),
+                meeting.getMeetingStatus().name());
+    }
+}

--- a/src/main/java/com/jolupbisang/demo/application/meeting/exception/MeetingErrorCode.java
+++ b/src/main/java/com/jolupbisang/demo/application/meeting/exception/MeetingErrorCode.java
@@ -8,7 +8,9 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum MeetingErrorCode implements ErrorCode {
-    NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다.");
+    NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다."),
+    INVALID_DATE(HttpStatus.BAD_REQUEST, "잘못된 회의 날짜 형식입니다."),
+    ;
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/jolupbisang/demo/application/meeting/service/MeetingService.java
+++ b/src/main/java/com/jolupbisang/demo/application/meeting/service/MeetingService.java
@@ -65,9 +65,7 @@ public class MeetingService {
     public void processAndSendAudioData(WebSocketSession session, BinaryMessage message) throws IOException {
         ByteBuffer buffer = message.getPayload();
         AudioMeta audioMeta = extractAudioMeta(buffer);
-        log.info("{}", audioMeta);
         byte[] audioData = extractAudioData(buffer);
-        log.info("{}", audioData);
         saveAudio(audioMeta, audioData);
     }
 

--- a/src/main/java/com/jolupbisang/demo/application/meeting/service/MeetingService.java
+++ b/src/main/java/com/jolupbisang/demo/application/meeting/service/MeetingService.java
@@ -2,6 +2,7 @@ package com.jolupbisang.demo.application.meeting.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jolupbisang.demo.application.common.validator.MeetingAccessValidator;
 import com.jolupbisang.demo.application.meeting.dto.AudioMeta;
 import com.jolupbisang.demo.application.meeting.dto.MeetingReq;
 import com.jolupbisang.demo.application.meeting.exception.MeetingErrorCode;
@@ -16,6 +17,7 @@ import com.jolupbisang.demo.infrastructure.agenda.AgendaRepository;
 import com.jolupbisang.demo.infrastructure.meeting.MeetingRepository;
 import com.jolupbisang.demo.infrastructure.meetingUser.MeetingUserRepository;
 import com.jolupbisang.demo.infrastructure.user.UserRepository;
+import com.jolupbisang.demo.presentation.meeting.dto.MeetingDetailRes;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -42,6 +44,7 @@ public class MeetingService {
     private final MeetingUserRepository meetingUserRepository;
     private final AgendaRepository agendaRepository;
 
+    private final MeetingAccessValidator meetingAccessValidator;
     private final MeetingProperties meetingProperties;
     private final ObjectMapper objectMapper;
 
@@ -60,6 +63,13 @@ public class MeetingService {
 
         agendaRepository.saveAll(meetingReq.agendas().stream().map(agenda ->
                 new Agenda(meeting, agenda)).toList());
+    }
+
+    public MeetingDetailRes getMeetingDetail(Long meetingId, Long userId) {
+        meetingAccessValidator.validateUserParticipating(meetingId, userId);
+
+        return MeetingDetailRes.fromEntity(meetingRepository.findById(meetingId)
+                .orElseThrow(() -> new CustomException(MeetingErrorCode.NOT_FOUND)));
     }
 
     public void processAndSendAudioData(WebSocketSession session, BinaryMessage message) throws IOException {

--- a/src/main/java/com/jolupbisang/demo/application/meeting/service/MeetingService.java
+++ b/src/main/java/com/jolupbisang/demo/application/meeting/service/MeetingService.java
@@ -66,6 +66,8 @@ public class MeetingService {
         ByteBuffer buffer = message.getPayload();
         AudioMeta audioMeta = extractAudioMeta(buffer);
         byte[] audioData = extractAudioData(buffer);
+
+        log.info("[{}] Audio accepted: userId: {}, meetingId: {}, chunkId: {}", session.getId(), audioMeta.userId(), audioMeta.meetingId(), audioMeta.chunkId());
         saveAudio(audioMeta, audioData);
     }
 

--- a/src/main/java/com/jolupbisang/demo/global/config/WebSocketConfig.java
+++ b/src/main/java/com/jolupbisang/demo/global/config/WebSocketConfig.java
@@ -1,22 +1,35 @@
 package com.jolupbisang.demo.global.config;
 
+import com.jolupbisang.demo.global.properties.WebSocketProperties;
 import com.jolupbisang.demo.presentation.meeting.MeetingSocketHandler;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.socket.config.annotation.EnableWebSocket;
 import org.springframework.web.socket.config.annotation.WebSocketConfigurer;
 import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry;
+import org.springframework.web.socket.server.standard.ServletServerContainerFactoryBean;
 
 @Configuration
 @EnableWebSocket
 @RequiredArgsConstructor
 public class WebSocketConfig implements WebSocketConfigurer {
 
+    private final WebSocketProperties webSocketProperties;
     private final MeetingSocketHandler meetingSocketHandler;
 
     @Override
     public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
         registry.addHandler(meetingSocketHandler, "/ws/meeting")
                 .setAllowedOrigins("*");
+    }
+
+    @Bean
+    public ServletServerContainerFactoryBean createWebSocketContainer() {
+        ServletServerContainerFactoryBean container = new ServletServerContainerFactoryBean();
+        container.setMaxTextMessageBufferSize(webSocketProperties.getTextBufferSize());
+        container.setMaxBinaryMessageBufferSize(webSocketProperties.getBinaryBufferSize());
+        container.setMaxSessionIdleTimeout(webSocketProperties.getSessionTimeout());
+        return container;
     }
 }

--- a/src/main/java/com/jolupbisang/demo/global/properties/WebSocketProperties.java
+++ b/src/main/java/com/jolupbisang/demo/global/properties/WebSocketProperties.java
@@ -1,0 +1,16 @@
+package com.jolupbisang.demo.global.properties;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@ConfigurationProperties("websocket")
+@Component
+public class WebSocketProperties {
+    private String textBufferSize;
+    private String binaryBufferSize;
+    private String sessionTimeout;
+}

--- a/src/main/java/com/jolupbisang/demo/global/properties/WebSocketProperties.java
+++ b/src/main/java/com/jolupbisang/demo/global/properties/WebSocketProperties.java
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Component;
 @ConfigurationProperties("websocket")
 @Component
 public class WebSocketProperties {
-    private String textBufferSize;
-    private String binaryBufferSize;
-    private String sessionTimeout;
+    private Integer textBufferSize;
+    private Integer binaryBufferSize;
+    private Long sessionTimeout;
 }

--- a/src/main/java/com/jolupbisang/demo/infrastructure/meeting/MeetingRepository.java
+++ b/src/main/java/com/jolupbisang/demo/infrastructure/meeting/MeetingRepository.java
@@ -3,5 +3,5 @@ package com.jolupbisang.demo.infrastructure.meeting;
 import com.jolupbisang.demo.domain.meeting.Meeting;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface MeetingRepository extends JpaRepository<Meeting, Long> {
+public interface MeetingRepository extends JpaRepository<Meeting, Long>, MeetingRepositoryCustom {
 }

--- a/src/main/java/com/jolupbisang/demo/infrastructure/meeting/MeetingRepositoryCustom.java
+++ b/src/main/java/com/jolupbisang/demo/infrastructure/meeting/MeetingRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.jolupbisang.demo.infrastructure.meeting;
+
+import com.jolupbisang.demo.domain.meeting.Meeting;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface MeetingRepositoryCustom {
+    List<Meeting> findByUserIdAndStartTimeBetween(Long userId, LocalDateTime startOfMonth, LocalDateTime endOfMonth);
+}

--- a/src/main/java/com/jolupbisang/demo/infrastructure/meeting/MeetingRepositoryImpl.java
+++ b/src/main/java/com/jolupbisang/demo/infrastructure/meeting/MeetingRepositoryImpl.java
@@ -1,0 +1,31 @@
+package com.jolupbisang.demo.infrastructure.meeting;
+
+import com.jolupbisang.demo.domain.meeting.Meeting;
+import com.jolupbisang.demo.domain.meetingUser.MeetingUserStatus;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static com.jolupbisang.demo.domain.meeting.QMeeting.meeting;
+import static com.jolupbisang.demo.domain.meetingUser.QMeetingUser.meetingUser;
+
+@RequiredArgsConstructor
+public class MeetingRepositoryImpl implements MeetingRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<Meeting> findByUserIdAndStartTimeBetween(Long userId, LocalDateTime startOfMonth, LocalDateTime endOfMonth) {
+        return queryFactory.selectFrom(meeting)
+                .where(meeting.id.in(
+                                JPAExpressions.select(meetingUser.meeting.id)
+                                        .from(meetingUser)
+                                        .where(meetingUser.user.id.eq(userId)
+                                                .and(meetingUser.status.eq(MeetingUserStatus.ACCEPTED))))
+                        .and(meeting.scheduledStartTime.between(startOfMonth, endOfMonth)))
+                .fetch();
+    }
+}

--- a/src/main/java/com/jolupbisang/demo/presentation/meeting/MeetingController.java
+++ b/src/main/java/com/jolupbisang/demo/presentation/meeting/MeetingController.java
@@ -8,10 +8,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -26,5 +23,12 @@ public class MeetingController {
         meetingService.createMeeting(meetingReq, userDetails.getUserId());
 
         return ResponseEntity.status(HttpStatus.CREATED).body("회의 생성 성공");
+    }
+
+    @GetMapping("/{meetingId}")
+    public ResponseEntity<?> getMeetingDetail(@PathVariable Long meetingId,
+                                              @AuthenticationPrincipal CustomUserDetails userDetails) {
+
+        return ResponseEntity.ok(meetingService.getMeetingDetail(meetingId, userDetails.getUserId()));
     }
 }

--- a/src/main/java/com/jolupbisang/demo/presentation/meeting/MeetingController.java
+++ b/src/main/java/com/jolupbisang/demo/presentation/meeting/MeetingController.java
@@ -3,6 +3,7 @@ package com.jolupbisang.demo.presentation.meeting;
 import com.jolupbisang.demo.application.meeting.dto.MeetingReq;
 import com.jolupbisang.demo.application.meeting.service.MeetingService;
 import com.jolupbisang.demo.infrastructure.auth.security.CustomUserDetails;
+import com.jolupbisang.demo.presentation.meeting.dto.MeetingDetailSummaryRes;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -30,5 +31,17 @@ public class MeetingController {
                                               @AuthenticationPrincipal CustomUserDetails userDetails) {
 
         return ResponseEntity.ok(meetingService.getMeetingDetail(meetingId, userDetails.getUserId()));
+    }
+
+    @GetMapping
+    public ResponseEntity<?> getMeetings(@RequestParam("year") Integer year,
+                                         @RequestParam("month") Integer month,
+                                         @AuthenticationPrincipal CustomUserDetails userDetails) {
+
+        MeetingDetailSummaryRes response = MeetingDetailSummaryRes.fromDto(
+                meetingService.getMeetingsByYearAndMonth(year, month, userDetails.getUserId())
+        );
+        
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/jolupbisang/demo/presentation/meeting/MeetingSocketHandler.java
+++ b/src/main/java/com/jolupbisang/demo/presentation/meeting/MeetingSocketHandler.java
@@ -24,7 +24,6 @@ public class MeetingSocketHandler extends BinaryWebSocketHandler {
 
     @Override
     protected void handleBinaryMessage(WebSocketSession session, BinaryMessage message) throws Exception {
-        log.info("핸들러 도착");
         meetingService.processAndSendAudioData(session, message);
     }
 

--- a/src/main/java/com/jolupbisang/demo/presentation/meeting/MeetingSocketHandler.java
+++ b/src/main/java/com/jolupbisang/demo/presentation/meeting/MeetingSocketHandler.java
@@ -7,6 +7,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.web.socket.BinaryMessage;
 import org.springframework.web.socket.CloseStatus;
+import org.springframework.web.socket.TextMessage;
 import org.springframework.web.socket.WebSocketSession;
 import org.springframework.web.socket.handler.BinaryWebSocketHandler;
 
@@ -19,7 +20,7 @@ public class MeetingSocketHandler extends BinaryWebSocketHandler {
 
     @Override
     public void afterConnectionEstablished(WebSocketSession session) throws Exception {
-        log.info("WebSocket Connection Established: {}", session.getId());
+        log.info("[{}] WebSocket Connection Established", session.getId());
     }
 
     @Override
@@ -28,7 +29,13 @@ public class MeetingSocketHandler extends BinaryWebSocketHandler {
     }
 
     @Override
+    public void handleTransportError(WebSocketSession session, Throwable exception) throws Exception {
+        session.sendMessage(new TextMessage("Error: " + exception.getMessage()));
+        log.info("[{}] WebSocket Transport Error: {}", session.getId(), exception.getMessage());
+    }
+
+    @Override
     public void afterConnectionClosed(WebSocketSession session, CloseStatus status) throws Exception {
-        log.info("WebSocket Connection Closed: {} - Status: {}", session.getId(), status);
+        log.info("[{}] WebSocket Connection Closed - Status: {}", session.getId(), status);
     }
 }

--- a/src/main/java/com/jolupbisang/demo/presentation/meeting/dto/MeetingDetailRes.java
+++ b/src/main/java/com/jolupbisang/demo/presentation/meeting/dto/MeetingDetailRes.java
@@ -1,0 +1,28 @@
+package com.jolupbisang.demo.presentation.meeting.dto;
+
+import com.jolupbisang.demo.domain.meeting.Meeting;
+
+import java.time.LocalDateTime;
+
+public record MeetingDetailRes(
+        Long meetingId,
+        String title,
+        String location,
+        LocalDateTime scheduledStartTime,
+        Integer targetTime,
+        Integer restInterval,
+        String meetingStatus
+) {
+
+    public static MeetingDetailRes fromEntity(Meeting meeting) {
+        return new MeetingDetailRes(
+                meeting.getId(),
+                meeting.getTitle(),
+                meeting.getLocation(),
+                meeting.getScheduledStartTime(),
+                meeting.getTargetTime(),
+                meeting.getRestInterval(),
+                meeting.getMeetingStatus().name()
+        );
+    }
+}

--- a/src/main/java/com/jolupbisang/demo/presentation/meeting/dto/MeetingDetailSummaryRes.java
+++ b/src/main/java/com/jolupbisang/demo/presentation/meeting/dto/MeetingDetailSummaryRes.java
@@ -1,0 +1,17 @@
+package com.jolupbisang.demo.presentation.meeting.dto;
+
+import com.jolupbisang.demo.application.meeting.dto.MeetingDetailSummary;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public record MeetingDetailSummaryRes(
+        List<MeetingDetailSummary> meetings
+) {
+
+    public static MeetingDetailSummaryRes fromDto(List<MeetingDetailSummary> meetings) {
+        return new MeetingDetailSummaryRes(
+                new ArrayList<>(meetings)
+        );
+    }
+}


### PR DESCRIPTION
## 구현 기능
- WebSocket 환경변수 추가
- 회의 단건 조회 기능 추가
- 월별 회의 목록 조회 기능 추가

## 테스트
1. 회의 단건 조회 성공
<img width="1066" alt="0시43분3초 am 2025-04-14 오전 11 51 50" src="https://github.com/user-attachments/assets/45d73dda-2e53-46c6-ac9f-c1ab235ad1df" />

2. 회의 단건 조회 실패(권한 없음 또는 참여중X)
<img width="1068" alt="0시43분3초 am 2025-04-14 오전 11 51 08" src="https://github.com/user-attachments/assets/25c2c334-4bfd-4222-8b98-057fe2631012" />

4. 회의 목록 조회 성공
<img width="1066" alt="0시43분3초 am 2025-04-14 오전 11 50 54" src="https://github.com/user-attachments/assets/e952c54d-3e27-491a-8ebe-c65b5eb9c9e4" />

5. 회의 목록 조회 실패 (잘못된 날짜 입력)
<img width="1069" alt="0시43분3초 am 2025-04-14 오전 11 50 34" src="https://github.com/user-attachments/assets/f5e5f190-c877-4a4e-afc2-217e3fdc0564" />
