### PR TITLE
feat: 회의 안건(Agenda) 조회 기능 추가

### DIFF
--- a/src/main/java/com/jolupbisang/demo/application/agenda/dto/AgendaDetail.java
+++ b/src/main/java/com/jolupbisang/demo/application/agenda/dto/AgendaDetail.java
@@ -1,0 +1,18 @@
+package com.jolupbisang.demo.application.agenda.dto;
+
+import com.jolupbisang.demo.domain.agenda.Agenda;
+
+public record AgendaDetail(
+        Long agendaId,
+        String content,
+        boolean isCompleted
+) {
+
+    public static AgendaDetail fromEntity(Agenda agenda) {
+        return new AgendaDetail(
+                agenda.getId(),
+                agenda.getContent(),
+                agenda.isCompleted()
+        );
+    }
+}

--- a/src/main/java/com/jolupbisang/demo/application/agenda/service/AgendaService.java
+++ b/src/main/java/com/jolupbisang/demo/application/agenda/service/AgendaService.java
@@ -1,21 +1,22 @@
 package com.jolupbisang.demo.application.agenda.service;
 
+import com.jolupbisang.demo.application.agenda.dto.AgendaDetail;
 import com.jolupbisang.demo.application.agenda.exception.AgendaErrorCode;
+import com.jolupbisang.demo.application.common.validator.MeetingAccessValidator;
 import com.jolupbisang.demo.domain.agenda.Agenda;
 import com.jolupbisang.demo.global.exception.CustomException;
 import com.jolupbisang.demo.infrastructure.agenda.AgendaRepository;
-import com.jolupbisang.demo.infrastructure.meeting.MeetingRepository;
-import com.jolupbisang.demo.infrastructure.user.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class AgendaService {
     private final AgendaRepository agendaRepository;
-    private final UserRepository userRepository;
-    private final MeetingRepository meetingRepository;
+    private final MeetingAccessValidator meetingAccessValidator;
 
     @Transactional
     public void changeAgendaStatus(Long agendaId, Long userId, boolean isCompleted) {
@@ -23,5 +24,15 @@ public class AgendaService {
                 .orElseThrow(() -> new CustomException(AgendaErrorCode.UNAUTHORIZED));
 
         agenda.setIsCompleted(isCompleted);
+    }
+
+    public List<AgendaDetail> findByMeetingId(Long meetingId, Long userId) {
+        meetingAccessValidator.validateUserParticipating(meetingId, userId);
+
+        List<Agenda> agendas = agendaRepository.findByMeetingId(meetingId);
+
+        return agendas.stream()
+                .map(AgendaDetail::fromEntity)
+                .toList();
     }
 }

--- a/src/main/java/com/jolupbisang/demo/application/common/validator/MeetingAccessValidator.java
+++ b/src/main/java/com/jolupbisang/demo/application/common/validator/MeetingAccessValidator.java
@@ -25,11 +25,7 @@ public class MeetingAccessValidator {
             throw new CustomException(MeetingAccessErrorCode.NOT_IN_PROGRESS);
         }
 
-        boolean isParticipant = meetingUserRepository.existsByMeetingIdAndUserIdAndStatusIn(meetingId, userId, MeetingUserStatus.ACCEPTED);
-
-        if (!isParticipant) {
-            throw new CustomException(MeetingAccessErrorCode.NOT_PARTICIPANT);
-        }
+        validateUserParticipating(meetingId, userId);
     }
 
     public void validateUserParticipating(Long meetingId, Long userId) {

--- a/src/main/java/com/jolupbisang/demo/infrastructure/agenda/AgendaRepository.java
+++ b/src/main/java/com/jolupbisang/demo/infrastructure/agenda/AgendaRepository.java
@@ -3,5 +3,8 @@ package com.jolupbisang.demo.infrastructure.agenda;
 import com.jolupbisang.demo.domain.agenda.Agenda;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface AgendaRepository extends JpaRepository<Agenda, Long>, AgendaRepositoryCustom {
+    List<Agenda> findByMeetingId(Long meetingId);
 }

--- a/src/main/java/com/jolupbisang/demo/presentation/agenda/AgendaController.java
+++ b/src/main/java/com/jolupbisang/demo/presentation/agenda/AgendaController.java
@@ -2,6 +2,7 @@ package com.jolupbisang.demo.presentation.agenda;
 
 import com.jolupbisang.demo.application.agenda.service.AgendaService;
 import com.jolupbisang.demo.infrastructure.auth.security.CustomUserDetails;
+import com.jolupbisang.demo.presentation.agenda.dto.AgendaDetailRes;
 import com.jolupbisang.demo.presentation.agenda.dto.AgendaStatusReq;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -26,5 +27,13 @@ public class AgendaController {
                 agendaStatusReq.isCompleted());
 
         return ResponseEntity.status(HttpStatus.ACCEPTED).body("회의 안건 상태 변경 성공");
+    }
+
+    @GetMapping("/{meetingId}")
+    public ResponseEntity<?> getAgendas(@PathVariable("meetingId") Long meetingId,
+                                        @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+
+        return ResponseEntity.status(HttpStatus.OK).body(
+                AgendaDetailRes.fromDto(agendaService.findByMeetingId(meetingId, customUserDetails.getUserId())));
     }
 }

--- a/src/main/java/com/jolupbisang/demo/presentation/agenda/dto/AgendaDetailRes.java
+++ b/src/main/java/com/jolupbisang/demo/presentation/agenda/dto/AgendaDetailRes.java
@@ -1,0 +1,24 @@
+package com.jolupbisang.demo.presentation.agenda.dto;
+
+import com.jolupbisang.demo.application.agenda.dto.AgendaDetail;
+
+import java.util.List;
+
+public record AgendaDetailRes(
+        List<DetailDto> agendaDetails
+) {
+    public static AgendaDetailRes fromDto(List<AgendaDetail> details) {
+        return new AgendaDetailRes(
+                details.stream()
+                        .map(detail ->
+                                new DetailDto(detail.agendaId(), detail.content(), detail.isCompleted()))
+                        .toList());
+    }
+
+    private record DetailDto(
+            Long agendaId,
+            String content,
+            boolean isCompleted
+    ) {
+    }
+}


### PR DESCRIPTION
## 구현기능
- meetingId 기준 Agenda 조회 기능 추가

## 테스트
1. 조회 성공

<img width="1018" alt="0시43분3초 am 2025-04-15 오전 1 27 50" src="https://github.com/user-attachments/assets/06dbba57-879c-49f4-9c9d-acfeeb1cb0c6" />




2. 조회 실패 (권한 없음 또는 없는 회의)

<img width="1020" alt="0시43분3초 am 2025-04-15 오전 1 27 45" src="https://github.com/user-attachments/assets/9560b0a6-2e4f-452a-b627-ae6f70b6cd71" />
