### PR TITLE
feat: 회의 생성 및 조회 시 쉬는시간 길이 필드 추가

### DIFF
--- a/src/main/java/com/jolupbisang/demo/domain/meeting/Meeting.java
+++ b/src/main/java/com/jolupbisang/demo/domain/meeting/Meeting.java
@@ -33,6 +33,9 @@ public class Meeting extends BaseTimeEntity {
     @Column(nullable = false)
     private int restInterval;
 
+    @Column(nullable = false)
+    private int restDuration;
+
     @Enumerated(EnumType.STRING)
     private MeetingStatus meetingStatus;
 
@@ -42,11 +45,12 @@ public class Meeting extends BaseTimeEntity {
 
     private String recordUrl;
 
-    public Meeting(String title, String location, LocalDateTime scheduledStartTime, int targetTime, int restInterval) {
+    public Meeting(String title, String location, LocalDateTime scheduledStartTime, int targetTime, int restInterval, int restDuration) {
         this.title = title;
         this.location = location;
         this.scheduledStartTime = scheduledStartTime;
         this.targetTime = targetTime;
         this.restInterval = restInterval;
+        this.restDuration = restDuration;
     }
 }

--- a/src/main/java/com/jolupbisang/demo/presentation/meeting/dto/request/MeetingReq.java
+++ b/src/main/java/com/jolupbisang/demo/presentation/meeting/dto/request/MeetingReq.java
@@ -31,8 +31,13 @@ public record MeetingReq(
 
         @Schema(description = "회의 휴식 시간(분)", example = "10")
         @NotNull(message = "회의 휴식 시간은 필수입니다.")
-        @Min(value = 0, message = "회의 휴식 시간은 0분 이상이어야 합니다.")
+        @Min(value = 0, message = "회의 휴식 시간 간격은 0분 이상이어야 합니다.")
         Integer restInterval,
+
+        @Schema(description = "회의 휴식 시간 길이(분)", example = "5")
+        @NotNull(message = "회의 휴식 시간 길이는 필수입니다.")
+        @Min(value = 1, message = "회의 휴식 시간 길이는 1분 이상이어야 합니다.")
+        Integer restDuration,
 
         @Schema(description = "참여자 목록")
         @NotNull(message = "참여자 목록은 필수입니다.")
@@ -43,6 +48,6 @@ public record MeetingReq(
         List<@NotBlank(message = "회의 안건은 1글자 이상이어야 합니다.") String> agendas
 ) {
     public Meeting toEntity() {
-        return new Meeting(title, location, scheduledStartTime, targetTime, restInterval);
+        return new Meeting(title, location, scheduledStartTime, targetTime, restInterval, restDuration);
     }
 }

--- a/src/main/java/com/jolupbisang/demo/presentation/meeting/dto/response/MeetingDetailRes.java
+++ b/src/main/java/com/jolupbisang/demo/presentation/meeting/dto/response/MeetingDetailRes.java
@@ -11,6 +11,7 @@ public record MeetingDetailRes(
         LocalDateTime scheduledStartTime,
         Integer targetTime,
         Integer restInterval,
+        Integer restDuration,
         String meetingStatus
 ) {
 
@@ -22,6 +23,7 @@ public record MeetingDetailRes(
                 meeting.getScheduledStartTime(),
                 meeting.getTargetTime(),
                 meeting.getRestInterval(),
+                meeting.getRestDuration(),
                 meeting.getMeetingStatus().name()
         );
     }


### PR DESCRIPTION
## 구현내용
- 회의 생성 및 조회 시 쉬는시간 길이 필드 추가

## 테스트
1.1. 회의 생성 성공

<img width="1019" alt="0시43분3초 am 2025-05-02 오후 11 57 45" src="https://github.com/user-attachments/assets/79b4c789-aefe-449e-a859-ffe3bc477317" />

1.2. DTO 검증 실패

<img width="1013" alt="0시43분3초 am 2025-05-02 오후 11 58 18" src="https://github.com/user-attachments/assets/5b7b153b-3d7f-41d0-86cb-400120127a8f" />

1.3. DTO 배열 요소 검증 실패

<img width="1018" alt="0시43분3초 am 2025-05-02 오후 11 58 30" src="https://github.com/user-attachments/assets/2891ab2a-60b1-4864-8964-c4374df2e294" />

2.1. 회의 내용 조회 성공

<img width="1015" alt="0시43분3초 am 2025-05-02 오후 11 57 34" src="https://github.com/user-attachments/assets/4c1ed2c7-1cc5-4103-b2db-f861fd7202f1" />

2.2. 회의 내용 조회 실패 - 참여자 X

<img width="1015" alt="0시43분3초 am 2025-05-02 오후 11 57 18" src="https://github.com/user-attachments/assets/12213e89-aff4-44ba-b40d-17310f487be9" />