### PR TITLE
feat: 세션관리 로직 추가 및 소켓 인증 로직 구현

### DIFF
--- a/src/main/java/com/jolupbisang/demo/application/meeting/dto/AudioMeta.java
+++ b/src/main/java/com/jolupbisang/demo/application/meeting/dto/AudioMeta.java
@@ -6,7 +6,7 @@ public record AudioMeta(
         String type,
         long userId,
         long meetingId,
-        int chunkId,
+        long chunkId,
         LocalDateTime timestamp,
         String encoding
 ) {

--- a/src/main/java/com/jolupbisang/demo/application/meeting/exception/AudioError.java
+++ b/src/main/java/com/jolupbisang/demo/application/meeting/exception/AudioError.java
@@ -8,7 +8,16 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum AudioError implements ErrorCode {
-    INVALID_META_DATA(HttpStatus.BAD_REQUEST, "잘못된 메타 데이터 형식입니다.");
+    SESSION_INFO_NOT_FOUND(HttpStatus.UNAUTHORIZED, "세션 정보를 찾을 수 없거나 유효하지 않습니다. 다시 연결해주세요."),
+    INVALID_MEETING_ID_FORMAT(HttpStatus.BAD_REQUEST, "미팅 ID 형식이 올바르지 않습니다."),
+
+    INVALID_META_DATA(HttpStatus.BAD_REQUEST, "잘못된 메타 데이터 형식입니다."),
+    METADATA_TYPE_INVALID(HttpStatus.BAD_REQUEST, "오디오 메타데이터의 'type' 필드가 null이거나 비어있습니다."),
+    METADATA_CHUNKID_NULL(HttpStatus.BAD_REQUEST, "오디오 메타데이터의 'chunkId' 필드가 null입니다."),
+    METADATA_ENCODING_INVALID(HttpStatus.BAD_REQUEST, "오디오 메타데이터의 'encoding' 필드가 null이거나 비어있습니다."),
+    METADATA_TIMESTAMP_NULL(HttpStatus.BAD_REQUEST, "오디오 메타데이터의 'timestamp' 필드가 null이거나 유효한 날짜/시간 형식이 아닙니다."),
+    METADATA_INVALID_PAYLOAD_LENGTH(HttpStatus.BAD_REQUEST, "오디오 메타데이터 페이로드 길이가 유효하지 않습니다.");
+
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/jolupbisang/demo/application/meeting/service/AudioService.java
+++ b/src/main/java/com/jolupbisang/demo/application/meeting/service/AudioService.java
@@ -10,17 +10,16 @@ import com.jolupbisang.demo.infrastructure.meeting.audio.AudioRepository;
 import com.jolupbisang.demo.infrastructure.meeting.client.WhisperClient;
 import com.jolupbisang.demo.infrastructure.meeting.session.MeetingSessionRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.web.socket.BinaryMessage;
-import org.springframework.web.socket.WebSocketSession;
 import org.springframework.web.socket.CloseStatus;
-import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.socket.WebSocketSession;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
-import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -34,12 +33,7 @@ public class AudioService {
     private final MeetingSessionRepository meetingSessionRepository;
 
     public void registerSessionAndValidateAccess(WebSocketSession session, Long meetingId, Long userId) {
-        Optional<WebSocketSession> existingSessionOpt = meetingSessionRepository.findByUserId(userId);
-
-        if (existingSessionOpt.isPresent()) {
-            closeAndRemoveExistingSession(existingSessionOpt.get(), userId);
-        }
-
+        meetingSessionRepository.findByUserId(userId).ifPresent(webSocketSession -> closeAndRemoveExistingSession(webSocketSession, userId));
         meetingAccessValidator.validateMeetingInProgressAndUserParticipating(meetingId, userId);
         meetingSessionRepository.save(session, userId, meetingId);
     }

--- a/src/main/java/com/jolupbisang/demo/application/meeting/service/AudioService.java
+++ b/src/main/java/com/jolupbisang/demo/application/meeting/service/AudioService.java
@@ -8,8 +8,8 @@ import com.jolupbisang.demo.application.meeting.exception.AudioError;
 import com.jolupbisang.demo.global.exception.CustomException;
 import com.jolupbisang.demo.infrastructure.meeting.audio.AudioRepository;
 import com.jolupbisang.demo.infrastructure.meeting.client.WhisperClient;
+import com.jolupbisang.demo.infrastructure.meeting.session.MeetingSessionRepository;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.web.socket.BinaryMessage;
 import org.springframework.web.socket.WebSocketSession;
@@ -17,40 +17,62 @@ import org.springframework.web.socket.WebSocketSession;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
 
-@Slf4j
 @Service
 @RequiredArgsConstructor
 public class AudioService {
 
     private final AudioRepository audioRepository;
     private final WhisperClient whisperClient;
-    private final MeetingAccessValidator meetingAccessValidator;
-
     private final ObjectMapper objectMapper;
+    private final MeetingAccessValidator meetingAccessValidator;
+    private final MeetingSessionRepository meetingSessionRepository;
+
+    public void registerSessionAndValidateAccess(WebSocketSession session, Long meetingId, Long userId) {
+        meetingAccessValidator.validateMeetingInProgressAndUserParticipating(meetingId, userId);
+        meetingSessionRepository.save(session, userId, meetingId);
+    }
+
+    public void unregisterSession(WebSocketSession session) {
+        meetingSessionRepository.delete(session);
+    }
 
     public void processAndSaveAudioData(WebSocketSession session, BinaryMessage message) throws IOException {
+        long userId = meetingSessionRepository.getUserIdBySession(session)
+                .orElseThrow(() -> new CustomException(AudioError.SESSION_INFO_NOT_FOUND));
+
+        long meetingId = meetingSessionRepository.getMeetingIdBySession(session)
+                .orElseThrow(() -> new CustomException(AudioError.SESSION_INFO_NOT_FOUND));
+
         ByteBuffer buffer = message.getPayload();
-        AudioMeta audioMeta = extractAudioMeta(buffer);
+        AudioMeta audioMetaResult = getAudioMeta(buffer, userId, meetingId);
         byte[] audioData = extractAudioData(buffer);
 
-        log.info("[{}] Audio accepted: userId: {}, meetingId: {}, chunkId: {}", session.getId(), audioMeta.userId(), audioMeta.meetingId(), audioMeta.chunkId());
-
-        meetingAccessValidator.validateMeetingInProgressAndUserParticipating(audioMeta.meetingId(), audioMeta.userId());
-
-        audioRepository.save(audioMeta, audioData);
+        audioRepository.save(audioMetaResult, audioData);
         whisperClient.send(message);
     }
 
-    private AudioMeta extractAudioMeta(ByteBuffer byteBuffer) {
+    private AudioMeta getAudioMeta(ByteBuffer byteBuffer, long userId, long meetingId) {
+        AudioDetails audioDetails = extractAudioDetails(byteBuffer);
+        return audioDetails.toAudioMeta(userId, meetingId);
+    }
+
+    private AudioDetails extractAudioDetails(ByteBuffer byteBuffer) {
         int metaLength = byteBuffer.getInt();
-        byte[] metaData = new byte[metaLength];
-        byteBuffer.get(metaData);
-        String metaString = new String(metaData, StandardCharsets.UTF_8);
+        if (metaLength <= 0 || metaLength > byteBuffer.remaining()) {
+            throw new CustomException(AudioError.METADATA_INVALID_PAYLOAD_LENGTH);
+        }
+        byte[] metaDataBytes = new byte[metaLength];
+        byteBuffer.get(metaDataBytes);
+        String metaString = new String(metaDataBytes, StandardCharsets.UTF_8);
 
         try {
-            return objectMapper.readValue(metaString, AudioMeta.class);
+            return objectMapper.readValue(metaString, AudioDetails.class);
         } catch (JsonProcessingException ex) {
+            if (ex.getCause() instanceof CustomException) {
+                throw (CustomException) ex.getCause();
+            }
             throw new CustomException(AudioError.INVALID_META_DATA);
         }
     }
@@ -59,5 +81,33 @@ public class AudioService {
         byte[] audioBytes = new byte[byteBuffer.remaining()];
         byteBuffer.get(audioBytes);
         return audioBytes;
+    }
+
+    private record AudioDetails(String type, Long chunkId, String encoding, LocalDateTime timestamp) {
+        public AudioDetails {
+            if (type == null || type.trim().isEmpty()) {
+                throw new CustomException(AudioError.METADATA_TYPE_INVALID);
+            }
+            if (chunkId == null) {
+                throw new CustomException(AudioError.METADATA_CHUNKID_NULL);
+            }
+            if (encoding == null || encoding.trim().isEmpty()) {
+                throw new CustomException(AudioError.METADATA_ENCODING_INVALID);
+            }
+            if (timestamp == null) {
+                throw new CustomException(AudioError.METADATA_TIMESTAMP_NULL);
+            }
+        }
+
+        public AudioMeta toAudioMeta(long userId, long meetingId) {
+            return new AudioMeta(
+                    this.type,
+                    userId,
+                    meetingId,
+                    this.chunkId,
+                    this.timestamp,
+                    this.encoding
+            );
+        }
     }
 } 

--- a/src/main/java/com/jolupbisang/demo/application/meeting/service/AudioService.java
+++ b/src/main/java/com/jolupbisang/demo/application/meeting/service/AudioService.java
@@ -12,6 +12,7 @@ import com.jolupbisang.demo.infrastructure.meeting.session.MeetingSessionReposit
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.socket.BinaryMessage;
 import org.springframework.web.socket.CloseStatus;
 import org.springframework.web.socket.WebSocketSession;
@@ -32,16 +33,19 @@ public class AudioService {
     private final MeetingAccessValidator meetingAccessValidator;
     private final MeetingSessionRepository meetingSessionRepository;
 
+    @Transactional
     public void registerSessionAndValidateAccess(WebSocketSession session, Long meetingId, Long userId) {
         meetingSessionRepository.findByUserId(userId).ifPresent(webSocketSession -> closeAndRemoveExistingSession(webSocketSession, userId));
         meetingAccessValidator.validateMeetingInProgressAndUserParticipating(meetingId, userId);
         meetingSessionRepository.save(session, userId, meetingId);
     }
 
+    @Transactional
     public void unregisterSession(WebSocketSession session) {
         meetingSessionRepository.delete(session);
     }
 
+    @Transactional
     public void processAndSaveAudioData(WebSocketSession session, BinaryMessage message) throws IOException {
         long userId = meetingSessionRepository.getUserIdBySession(session)
                 .orElseThrow(() -> new CustomException(AudioError.SESSION_INFO_NOT_FOUND));

--- a/src/main/java/com/jolupbisang/demo/application/meeting/service/AudioService.java
+++ b/src/main/java/com/jolupbisang/demo/application/meeting/service/AudioService.java
@@ -5,27 +5,23 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jolupbisang.demo.application.meeting.dto.AudioMeta;
 import com.jolupbisang.demo.application.meeting.exception.AudioError;
 import com.jolupbisang.demo.global.exception.CustomException;
-import com.jolupbisang.demo.global.properties.MeetingProperties;
+import com.jolupbisang.demo.infrastructure.meeting.audio.AudioRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.web.socket.BinaryMessage;
 import org.springframework.web.socket.WebSocketSession;
 
-import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class AudioService {
 
-    private final MeetingProperties meetingProperties;
+    private final AudioRepository audioRepository;
     private final ObjectMapper objectMapper;
 
     public void processAndSaveAudioData(WebSocketSession session, BinaryMessage message) throws IOException {
@@ -36,27 +32,7 @@ public class AudioService {
         log.info("[{}] Audio accepted: userId: {}, meetingId: {}, chunkId: {}",
                 session.getId(), audioMeta.userId(), audioMeta.meetingId(), audioMeta.chunkId());
 
-        saveAudio(audioMeta, audioData);
-    }
-
-    private void saveAudio(AudioMeta audioMeta, byte[] audioData) throws IOException {
-        Path dirPath = Path.of(meetingProperties.getBaseDir(),
-                Long.toString(audioMeta.meetingId()),
-                Long.toString(audioMeta.userId()));
-        String filename = Integer.toString(audioMeta.chunkId());
-
-        if (!Files.exists(dirPath)) {
-            Files.createDirectories(dirPath);
-        }
-
-        File chunkFile = dirPath.resolve(filename).toFile();
-
-        try (FileOutputStream fos = new FileOutputStream(chunkFile)) {
-            fos.write(audioData);
-        } catch (IOException e) {
-            log.error("[Failed to save audio file] meetingId: {}, userId:{}, chunkId:{} ", audioMeta.meetingId(), audioMeta.userId(), audioMeta.chunkId(), e);
-            throw e;
-        }
+        audioRepository.save(audioMeta, audioData);
     }
 
     private AudioMeta extractAudioMeta(ByteBuffer byteBuffer) {

--- a/src/main/java/com/jolupbisang/demo/application/meeting/service/AudioService.java
+++ b/src/main/java/com/jolupbisang/demo/application/meeting/service/AudioService.java
@@ -6,6 +6,7 @@ import com.jolupbisang.demo.application.meeting.dto.AudioMeta;
 import com.jolupbisang.demo.application.meeting.exception.AudioError;
 import com.jolupbisang.demo.global.exception.CustomException;
 import com.jolupbisang.demo.infrastructure.meeting.audio.AudioRepository;
+import com.jolupbisang.demo.infrastructure.meeting.client.WhisperClient;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -22,6 +23,7 @@ import java.nio.charset.StandardCharsets;
 public class AudioService {
 
     private final AudioRepository audioRepository;
+    private final WhisperClient whisperClient;
     private final ObjectMapper objectMapper;
 
     public void processAndSaveAudioData(WebSocketSession session, BinaryMessage message) throws IOException {
@@ -33,6 +35,7 @@ public class AudioService {
                 session.getId(), audioMeta.userId(), audioMeta.meetingId(), audioMeta.chunkId());
 
         audioRepository.save(audioMeta, audioData);
+        whisperClient.send(message);
     }
 
     private AudioMeta extractAudioMeta(ByteBuffer byteBuffer) {

--- a/src/main/java/com/jolupbisang/demo/domain/meeting/Meeting.java
+++ b/src/main/java/com/jolupbisang/demo/domain/meeting/Meeting.java
@@ -37,6 +37,7 @@ public class Meeting extends BaseTimeEntity {
     private int restDuration;
 
     @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
     private MeetingStatus meetingStatus;
 
     private LocalDateTime actualStartTime;
@@ -52,5 +53,6 @@ public class Meeting extends BaseTimeEntity {
         this.targetTime = targetTime;
         this.restInterval = restInterval;
         this.restDuration = restDuration;
+        this.meetingStatus = MeetingStatus.WAITING;
     }
 }

--- a/src/main/java/com/jolupbisang/demo/global/config/WebSocketConfig.java
+++ b/src/main/java/com/jolupbisang/demo/global/config/WebSocketConfig.java
@@ -1,6 +1,7 @@
 package com.jolupbisang.demo.global.config;
 
 import com.jolupbisang.demo.global.properties.WebSocketProperties;
+import com.jolupbisang.demo.presentation.auth.interceptor.WebSocketAuthInterceptor;
 import com.jolupbisang.demo.presentation.meeting.MeetingSocketHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -17,10 +18,12 @@ public class WebSocketConfig implements WebSocketConfigurer {
 
     private final WebSocketProperties webSocketProperties;
     private final MeetingSocketHandler meetingSocketHandler;
+    private final WebSocketAuthInterceptor webSocketAuthInterceptor;
 
     @Override
     public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
-        registry.addHandler(meetingSocketHandler, "/ws/meeting")
+        registry.addHandler(meetingSocketHandler, "/ws/meeting/audio/**")
+                .addInterceptors(webSocketAuthInterceptor)
                 .setAllowedOrigins("*");
     }
 

--- a/src/main/java/com/jolupbisang/demo/global/config/WebSocketConfig.java
+++ b/src/main/java/com/jolupbisang/demo/global/config/WebSocketConfig.java
@@ -22,7 +22,7 @@ public class WebSocketConfig implements WebSocketConfigurer {
 
     @Override
     public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
-        registry.addHandler(meetingSocketHandler, "/ws/meeting/audio/**")
+        registry.addHandler(meetingSocketHandler, "/ws/meeting/audio/{meetingId}")
                 .addInterceptors(webSocketAuthInterceptor)
                 .setAllowedOrigins("*");
     }

--- a/src/main/java/com/jolupbisang/demo/global/exception/WebSocketErrorHandler.java
+++ b/src/main/java/com/jolupbisang/demo/global/exception/WebSocketErrorHandler.java
@@ -1,0 +1,51 @@
+package com.jolupbisang.demo.global.exception;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jolupbisang.demo.global.response.ErrorResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketSession;
+
+import java.io.IOException;
+import java.util.UUID;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class WebSocketErrorHandler {
+
+    private final ObjectMapper objectMapper;
+
+
+    public void handleWebSocketError(WebSocketSession session, Throwable exception) {
+        String errorId = UUID.randomUUID().toString();
+        ErrorCode errorCode = resolveErrorCode(exception);
+        String clientMessage = errorCode.getMessage();
+
+    
+        log.error("[WebSocket Error - ErrorId: {}, Session: {}] ResolvedMessage: {}",
+                errorId, session.getId(), clientMessage, exception);
+
+        if (session.isOpen()) {
+            try {
+                ErrorResponse errorResponse = ErrorResponse.of(clientMessage, errorId);
+                session.sendMessage(new TextMessage(objectMapper.writeValueAsString(errorResponse)));
+            } catch (Exception e) {
+                log.error("[WebSocket Send Fail - ErrorId: {}, Session: {}] Failed to send error response to client, SendExMsg: {}",
+                    errorId, session.getId(), exception.getMessage(), e);
+            }
+        }
+    }
+
+    private ErrorCode resolveErrorCode(Throwable exception) {
+        if (exception instanceof CustomException customEx) {
+            return customEx.getErrorCode();
+        } else if (exception instanceof IOException) {
+            return GlobalErrorCode.INTERNAL_SERVER_ERROR;
+        }
+
+        return GlobalErrorCode.INTERNAL_SERVER_ERROR;
+    }
+} 

--- a/src/main/java/com/jolupbisang/demo/infrastructure/meeting/audio/AudioRepository.java
+++ b/src/main/java/com/jolupbisang/demo/infrastructure/meeting/audio/AudioRepository.java
@@ -1,0 +1,11 @@
+package com.jolupbisang.demo.infrastructure.meeting.audio;
+
+import com.jolupbisang.demo.application.meeting.dto.AudioMeta;
+import org.springframework.stereotype.Repository;
+
+import java.io.IOException;
+
+@Repository
+public interface AudioRepository {
+    void save(AudioMeta audioMeta, byte[] audioData) throws IOException;
+}

--- a/src/main/java/com/jolupbisang/demo/infrastructure/meeting/audio/AudioRepositoryImpl.java
+++ b/src/main/java/com/jolupbisang/demo/infrastructure/meeting/audio/AudioRepositoryImpl.java
@@ -1,0 +1,43 @@
+package com.jolupbisang.demo.infrastructure.meeting.audio;
+
+import com.jolupbisang.demo.application.meeting.dto.AudioMeta;
+import com.jolupbisang.demo.global.properties.MeetingProperties;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Repository;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class AudioRepositoryImpl implements AudioRepository {
+    
+    private final MeetingProperties meetingProperties;
+    
+    @Override
+    public void save(AudioMeta audioMeta, byte[] audioData) throws IOException {
+        Path dirPath = Path.of(meetingProperties.getBaseDir(),
+                Long.toString(audioMeta.meetingId()),
+                Long.toString(audioMeta.userId()));
+        String filename = Integer.toString(audioMeta.chunkId());
+
+        if (!Files.exists(dirPath)) {
+            Files.createDirectories(dirPath);
+        }
+
+        File chunkFile = dirPath.resolve(filename).toFile();
+
+        try (FileOutputStream fos = new FileOutputStream(chunkFile)) {
+            fos.write(audioData);
+        } catch (IOException e) {
+            log.error("[Failed to save audio file] meetingId: {}, userId:{}, chunkId:{} ", 
+                    audioMeta.meetingId(), audioMeta.userId(), audioMeta.chunkId(), e);
+            throw e;
+        }
+    }
+}

--- a/src/main/java/com/jolupbisang/demo/infrastructure/meeting/audio/AudioRepositoryImpl.java
+++ b/src/main/java/com/jolupbisang/demo/infrastructure/meeting/audio/AudioRepositoryImpl.java
@@ -16,15 +16,15 @@ import java.nio.file.Path;
 @Repository
 @RequiredArgsConstructor
 public class AudioRepositoryImpl implements AudioRepository {
-    
+
     private final MeetingProperties meetingProperties;
-    
+
     @Override
     public void save(AudioMeta audioMeta, byte[] audioData) throws IOException {
         Path dirPath = Path.of(meetingProperties.getBaseDir(),
                 Long.toString(audioMeta.meetingId()),
                 Long.toString(audioMeta.userId()));
-        String filename = Integer.toString(audioMeta.chunkId());
+        String filename = Long.toString(audioMeta.chunkId());
 
         if (!Files.exists(dirPath)) {
             Files.createDirectories(dirPath);
@@ -35,7 +35,7 @@ public class AudioRepositoryImpl implements AudioRepository {
         try (FileOutputStream fos = new FileOutputStream(chunkFile)) {
             fos.write(audioData);
         } catch (IOException e) {
-            log.error("[Failed to save audio file] meetingId: {}, userId:{}, chunkId:{} ", 
+            log.error("[Failed to save audio file] meetingId: {}, userId:{}, chunkId:{} ",
                     audioMeta.meetingId(), audioMeta.userId(), audioMeta.chunkId(), e);
             throw e;
         }

--- a/src/main/java/com/jolupbisang/demo/infrastructure/meeting/client/WhisperClient.java
+++ b/src/main/java/com/jolupbisang/demo/infrastructure/meeting/client/WhisperClient.java
@@ -1,0 +1,14 @@
+package com.jolupbisang.demo.infrastructure.meeting.client;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.BinaryMessage;
+
+@Slf4j
+@Component
+public class WhisperClient {
+
+    public void send(BinaryMessage message) {
+        log.info("send to Whisper server, need to impl");
+    }
+}

--- a/src/main/java/com/jolupbisang/demo/infrastructure/meeting/session/MeetingSessionRepository.java
+++ b/src/main/java/com/jolupbisang/demo/infrastructure/meeting/session/MeetingSessionRepository.java
@@ -13,5 +13,7 @@ public interface MeetingSessionRepository {
 
     Optional<Long> getMeetingIdBySession(WebSocketSession session);
 
-    boolean existsBySession(WebSocketSession session);
+    Optional<WebSocketSession> findByUserId(Long userId);
+
+    void deleteByUserId(Long userId);
 } 

--- a/src/main/java/com/jolupbisang/demo/infrastructure/meeting/session/MeetingSessionRepository.java
+++ b/src/main/java/com/jolupbisang/demo/infrastructure/meeting/session/MeetingSessionRepository.java
@@ -1,0 +1,17 @@
+package com.jolupbisang.demo.infrastructure.meeting.session;
+
+import org.springframework.web.socket.WebSocketSession;
+
+import java.util.Optional;
+
+public interface MeetingSessionRepository {
+    void save(WebSocketSession session, Long userId, Long meetingId);
+
+    void delete(WebSocketSession session);
+
+    Optional<Long> getUserIdBySession(WebSocketSession session);
+
+    Optional<Long> getMeetingIdBySession(WebSocketSession session);
+
+    boolean existsBySession(WebSocketSession session);
+} 

--- a/src/main/java/com/jolupbisang/demo/infrastructure/meeting/session/MeetingSessionRepositoryImpl.java
+++ b/src/main/java/com/jolupbisang/demo/infrastructure/meeting/session/MeetingSessionRepositoryImpl.java
@@ -1,0 +1,60 @@
+package com.jolupbisang.demo.infrastructure.meeting.session;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Repository;
+import org.springframework.web.socket.WebSocketSession;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Slf4j
+@Repository
+public class MeetingSessionRepositoryImpl implements MeetingSessionRepository {
+
+    private final Map<String, SessionInfo> sessionMap = new ConcurrentHashMap<>();
+
+    @Override
+    public void save(WebSocketSession session, Long userId, Long meetingId) {
+        String sessionId = session.getId();
+        sessionMap.put(sessionId, new SessionInfo(userId, meetingId));
+        log.info("Session saved: sessionId={}, userId={}, meetingId={}", sessionId, userId, meetingId);
+    }
+
+    @Override
+    public void delete(WebSocketSession session) {
+        SessionInfo removed = sessionMap.remove(session.getId());
+        if (removed != null) {
+            log.info("Session deleted: sessionId={}, userId={}, meetingId={}", session.getId(), removed.userId(), removed.meetingId());
+        }
+    }
+
+    @Override
+    public Optional<Long> getUserIdBySession(WebSocketSession session) {
+        SessionInfo sessionInfo = sessionMap.get(session.getId());
+        if (sessionInfo == null) {
+            return Optional.empty();
+        }
+
+        return Optional.ofNullable(sessionInfo.userId());
+    }
+
+    @Override
+    public Optional<Long> getMeetingIdBySession(WebSocketSession session) {
+        SessionInfo sessionInfo = sessionMap.get(session.getId());
+        if (sessionInfo == null) {
+            return Optional.empty();
+        }
+
+        return Optional.ofNullable(sessionInfo.meetingId());
+    }
+
+
+    @Override
+    public boolean existsBySession(WebSocketSession session) {
+        return sessionMap.containsKey(session.getId());
+    }
+
+    record SessionInfo(Long userId, Long meetingId) {
+    }
+} 

--- a/src/main/java/com/jolupbisang/demo/presentation/auth/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/jolupbisang/demo/presentation/auth/filter/JwtAuthenticationFilter.java
@@ -24,7 +24,7 @@ import java.io.IOException;
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final UserDetailsService userDetailsService;
-    private final JwtProvider JwtProvider;
+    private final JwtProvider jwtProvider;
 
     private static final String TOKEN_TYPE = "Bearer ";
 
@@ -50,7 +50,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private String resolveAccessToken(String authToken) {
         String accessToken = authToken.substring(TOKEN_TYPE.length()).trim();
 
-        if (JwtProvider.isExpired(accessToken)) {
+        if (jwtProvider.isExpired(accessToken)) {
             throw new CustomException(GlobalErrorCode.EXPIRED_JWT);
         }
 
@@ -58,9 +58,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     }
 
     private Authentication getAuthentication(String token) {
-        Long userId = JwtProvider.getUserId(token);
-        String email = JwtProvider.getEmail(token);
-        String nickname = JwtProvider.getNickname(token);
+        Long userId = jwtProvider.getUserId(token);
+        String email = jwtProvider.getEmail(token);
+        String nickname = jwtProvider.getNickname(token);
 
         UserDetails userDetails = new CustomUserDetails(userId, email, nickname);
 

--- a/src/main/java/com/jolupbisang/demo/presentation/auth/interceptor/WebSocketAuthInterceptor.java
+++ b/src/main/java/com/jolupbisang/demo/presentation/auth/interceptor/WebSocketAuthInterceptor.java
@@ -1,0 +1,68 @@
+package com.jolupbisang.demo.presentation.auth.interceptor;
+
+import com.jolupbisang.demo.infrastructure.auth.JwtProvider;
+import com.jolupbisang.demo.infrastructure.auth.security.CustomUserDetails;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.http.server.ServletServerHttpRequest;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.WebSocketHandler;
+import org.springframework.web.socket.server.HandshakeInterceptor;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+import java.util.Map;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class WebSocketAuthInterceptor implements HandshakeInterceptor {
+
+    private final JwtProvider jwtProvider;
+    private static final String TOKEN_PARAM = "token";
+
+    @Override
+    public boolean beforeHandshake(ServerHttpRequest request, ServerHttpResponse response, WebSocketHandler wsHandler, Map<String, Object> attributes) {
+        if (!(request instanceof ServletServerHttpRequest)) {
+            return false;
+        }
+
+        String token = extractToken(request);
+        if (token == null) {
+            return false;
+        }
+
+        try {
+            CustomUserDetails userDetails = getUserDetails(token);
+            attributes.put("userDetails", userDetails);
+        } catch (Exception e) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public void afterHandshake(ServerHttpRequest request, ServerHttpResponse response, WebSocketHandler wsHandler, Exception exception) {
+        //필요시 작성
+    }
+
+    private String extractToken(ServerHttpRequest request) {
+        URI uri = request.getURI();
+
+        return UriComponentsBuilder.fromUri(uri)
+                .build()
+                .getQueryParams()
+                .getFirst(TOKEN_PARAM);
+    }
+
+    private CustomUserDetails getUserDetails(String token) {
+        Long userId = jwtProvider.getUserId(token);
+        String email = jwtProvider.getEmail(token);
+        String nickname = jwtProvider.getNickname(token);
+
+        return new CustomUserDetails(userId, email, nickname);
+    }
+} 

--- a/src/main/java/com/jolupbisang/demo/presentation/auth/interceptor/WebSocketAuthInterceptor.java
+++ b/src/main/java/com/jolupbisang/demo/presentation/auth/interceptor/WebSocketAuthInterceptor.java
@@ -31,6 +31,7 @@ public class WebSocketAuthInterceptor implements HandshakeInterceptor {
 
         String token = extractToken(request);
         if (token == null) {
+            log.warn("Handshake failed: Missing token in request URI: {}", request.getURI());
             return false;
         }
 

--- a/src/main/java/com/jolupbisang/demo/presentation/meeting/MeetingSocketHandler.java
+++ b/src/main/java/com/jolupbisang/demo/presentation/meeting/MeetingSocketHandler.java
@@ -39,6 +39,12 @@ public class MeetingSocketHandler extends BinaryWebSocketHandler {
 
         } catch (Exception ex) {
             webSocketErrorHandler.handleWebSocketError(session, ex);
+            try {
+                log.warn("[{}] Closing session due to exception during connection establishment: {}", session.getId(), ex.getMessage());
+                session.close(CloseStatus.NORMAL);
+            } catch (Exception closeEx) {
+                log.error("[{}] Error closing WebSocket session after handling initial error: {}", session.getId(), closeEx.getMessage(), closeEx);
+            }
         }
     }
 

--- a/src/main/java/com/jolupbisang/demo/presentation/meeting/MeetingSocketHandler.java
+++ b/src/main/java/com/jolupbisang/demo/presentation/meeting/MeetingSocketHandler.java
@@ -41,7 +41,7 @@ public class MeetingSocketHandler extends BinaryWebSocketHandler {
             webSocketErrorHandler.handleWebSocketError(session, ex);
             try {
                 log.warn("[{}] Closing session due to exception during connection establishment: {}", session.getId(), ex.getMessage());
-                session.close(CloseStatus.NORMAL);
+                session.close(CloseStatus.POLICY_VIOLATION);
             } catch (Exception closeEx) {
                 log.error("[{}] Error closing WebSocket session after handling initial error: {}", session.getId(), closeEx.getMessage(), closeEx);
             }

--- a/src/main/java/com/jolupbisang/demo/presentation/meeting/MeetingSocketHandler.java
+++ b/src/main/java/com/jolupbisang/demo/presentation/meeting/MeetingSocketHandler.java
@@ -2,20 +2,23 @@ package com.jolupbisang.demo.presentation.meeting;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jolupbisang.demo.application.meeting.service.AudioService;
+import com.jolupbisang.demo.application.meeting.exception.AudioError;
 import com.jolupbisang.demo.global.exception.CustomException;
-import com.jolupbisang.demo.global.exception.GlobalErrorCode;
-import com.jolupbisang.demo.global.response.ErrorResponse;
+import com.jolupbisang.demo.global.exception.WebSocketErrorHandler;
+import com.jolupbisang.demo.infrastructure.auth.security.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
 import org.springframework.web.socket.BinaryMessage;
 import org.springframework.web.socket.CloseStatus;
 import org.springframework.web.socket.TextMessage;
 import org.springframework.web.socket.WebSocketSession;
 import org.springframework.web.socket.handler.BinaryWebSocketHandler;
+import org.springframework.web.util.UriComponentsBuilder;
 
 import java.io.IOException;
-import java.util.UUID;
+import java.net.URI;
 
 @Slf4j
 @Component
@@ -23,60 +26,72 @@ import java.util.UUID;
 public class MeetingSocketHandler extends BinaryWebSocketHandler {
 
     private final AudioService audioService;
-    private final ObjectMapper objectMapper;
-
+    private final WebSocketErrorHandler webSocketErrorHandler;
+    
     @Override
-    public void afterConnectionEstablished(WebSocketSession session) throws Exception {
-        log.info("[{}] WebSocket Connection Established", session.getId());
+    public void afterConnectionEstablished(WebSocketSession session) {
+        try {
+            Long meetingId = extractMeetingIdFromUri(session);
+            Authentication authentication = (Authentication) session.getPrincipal();
+
+            if (authentication == null || !(authentication.getPrincipal() instanceof CustomUserDetails)) {
+                throw new IllegalArgumentException("Missing authentication details.");
+            }
+
+            CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
+            Long userId = userDetails.getUserId();
+            
+            log.info("[{}] Attempting to register session: userId={}, meetingId={}", session.getId(), userId, meetingId);
+            audioService.registerSessionAndValidateAccess(session, meetingId, userId);
+            log.info("[{}] Session registration successful: userId={}, meetingId={}", session.getId(), userId, meetingId);
+            
+        } catch (Exception ex) {
+            webSocketErrorHandler.handleWebSocketError(session, ex);
+        }
     }
 
     @Override
-    protected void handleBinaryMessage(WebSocketSession session, BinaryMessage message) throws Exception {
+    protected void handleBinaryMessage(WebSocketSession session, BinaryMessage message) {
         try {
             audioService.processAndSaveAudioData(session, message);
         } catch (Exception ex) {
-            handleExceptionAndNotifyClient(session, ex);
+            webSocketErrorHandler.handleWebSocketError(session, ex);
         }
     }
 
     @Override
-    public void handleTransportError(WebSocketSession session, Throwable exception) throws Exception {
-        session.sendMessage(new TextMessage("Error: " + exception.getMessage()));
-        log.info("[{}] WebSocket Transport Error: {}", session.getId(), exception.getMessage());
+    public void handleTransportError(WebSocketSession session, Throwable exception) {
+        log.warn("[{}] WebSocket Transport Error: {}", session.getId(), exception.getMessage());
+        webSocketErrorHandler.handleWebSocketError(session, exception);
     }
 
     @Override
-    public void afterConnectionClosed(WebSocketSession session, CloseStatus status) throws Exception {
-        log.info("[{}] WebSocket Connection Closed - Status: {}", session.getId(), status);
-    }
-
-    private void handleExceptionAndNotifyClient(WebSocketSession session, Exception ex) {
-        log.error("[{}] Exception during WebSocket operation: {}", session.getId(), ex.getMessage(), ex);
-
+    public void afterConnectionClosed(WebSocketSession session, CloseStatus status) {
         try {
-            if (session.isOpen()) {
-                sendErrorResponse(session, ex);
-                log.debug("[{}] Error message sent to client", session.getId());
-            } else {
-                log.debug("[{}] Session closed, cannot send error message", session.getId());
-            }
-        } catch (Exception sendEx) {
-            log.error("[{}] Failed to send error message: {}", session.getId(), sendEx.getMessage());
+            audioService.unregisterSession(session);
+        } catch (Exception ex) {
+            log.error("[{}] Exception during session unregistration via AudioService on connection closed. Status: {}", 
+                    session.getId(), status, ex);
         }
+        log.debug("[{}] WebSocket Connection Closed - Status: {}. Session unregistration attempted.", session.getId(), status);
     }
 
-    private void sendErrorResponse(WebSocketSession session, Exception ex) throws IOException {
-        String errorId = UUID.randomUUID().toString();
-        ErrorResponse errorResponse = buildErrorResponse(ex, errorId);
-
-        log.error("[{}] Exception occurred: {}", errorId, errorResponse.message(), ex);
-        session.sendMessage(new TextMessage(objectMapper.writeValueAsString(errorResponse)));
-    }
-
-    private ErrorResponse buildErrorResponse(Exception ex, String errorId) {
-        if (ex instanceof CustomException) {
-            return ErrorResponse.of(((CustomException) ex).getErrorCode().getMessage(), errorId);
+    private Long extractMeetingIdFromUri(WebSocketSession session) {
+        URI uri = session.getUri();
+        if (uri == null) {
+            throw new IllegalStateException("WebSocket URI is null.");
         }
-        return ErrorResponse.of(GlobalErrorCode.INTERNAL_SERVER_ERROR.getMessage(), errorId);
+        
+        String path = uri.getPath();
+        if (path == null || !path.startsWith("/ws/meeting/")) {
+            throw new IllegalArgumentException("Invalid WebSocket path format.");
+        }
+        
+        String meetingIdStr = path.substring("/ws/meeting/".length());
+        try {
+            return Long.parseLong(meetingIdStr);
+        } catch (NumberFormatException nfe) {
+            throw new IllegalArgumentException("Invalid meeting ID format: " + meetingIdStr);
+        }
     }
 }


### PR DESCRIPTION
## 구현기능
- 오디오 저장 로직을 Repository로 분리
- SessionRepository로 Session 및 사용자 정보를 관리
- WebSocketErrorHandler로 Websocket 예외처리 로직 분리
- WebSocket의 HandshakeInterceptor를 활용해 WebSocket의 JWT 인증 로직 구현
- WebSocket 연결시 권한 확인
- 기존 코드 리팩토링

## 이슈
- meeting 생성시 MeetingStatus가 설정되지 않던 문제 수정
- 프론트에서 WebSocket API 사용시 헤더 설정이 불가 -> 기존 헤더에 JWT를 삽입하는 로직이 불가능
     - 핸드쉐이크 요청시 쿼리파라미터에 JWT를 넣도록 변경 (WebSocket에만 해당)

## 테스트
### 최초 연결시 권한 확인
1. 정상 연결
<img width="1015" alt="0시43분3초 am 2025-05-13 오후 6 08 00" src="https://github.com/user-attachments/assets/d742443a-cc48-45da-a6a8-9480403ab408" />

2. 회의의 참여자가 아님 -> 연결 종료
<img width="1021" alt="0시43분3초 am 2025-05-13 오후 6 08 19" src="https://github.com/user-attachments/assets/c5e35c5c-03c5-4041-bce4-ab2c52dc118b" />

3. 진행중인 회의가 아님 -> 연결 종료
<img width="1015" alt="0시43분3초 am 2025-05-13 오후 6 09 33" src="https://github.com/user-attachments/assets/042d078f-9bd5-4313-a771-28801d2e424e" />

### 연결 후 데이터 전송
1. 정상 전송
<img width="1016" alt="0시43분3초 am 2025-05-13 오후 6 23 27" src="https://github.com/user-attachments/assets/3c30fa18-3d7b-4aa0-be1e-722e0efb5825" />

2. 잘못된 메타데이터 형식
<img width="1013" alt="0시43분3초 am 2025-05-13 오후 7 22 14" src="https://github.com/user-attachments/assets/65818137-5a13-460a-8ff4-1130ef5f6065" />

