### PR TITLE
fix: 텍스트변환 메세지 전송 시 생성자 순서 변경

### DIFF
--- a/src/main/java/com/jolupbisang/demo/infrastructure/meeting/client/dto/request/DiarizedRequest.java
+++ b/src/main/java/com/jolupbisang/demo/infrastructure/meeting/client/dto/request/DiarizedRequest.java
@@ -14,11 +14,11 @@ import java.nio.charset.StandardCharsets;
 public record DiarizedRequest(
         WhisperRequestType flag,
 
-        @JsonProperty("user_id")
-        String userId,
-
         @JsonProperty("group_id")
         String groupId,
+
+        @JsonProperty("user_id")
+        String userId,
 
         @JsonProperty("sc_offset")
         String scOffset,
@@ -27,11 +27,11 @@ public record DiarizedRequest(
         byte[] audio
 ) {
 
-    public static DiarizedRequest of(long userId, long groupId, Integer scOffest, byte[] audio) {
+    public static DiarizedRequest of(long groupId, long userId, Integer scOffest, byte[] audio) {
         return new DiarizedRequest(
                 WhisperRequestType.DIARIZATION,
-                String.valueOf(userId),
                 String.valueOf(groupId),
+                String.valueOf(userId),
                 scOffest == null ? null : String.valueOf(scOffest),
                 audio);
     }


### PR DESCRIPTION
## 수정 내용
생성자 매개변수 순서 때문에 meetingId가 userId로 가는 문제 해결