### PR TITLE
feat: 아젠다 수정 기능 추가 및 아젠다 상태 변환 시 알림기능 추가

### DIFF
--- a/src/main/java/com/jolupbisang/demo/application/agenda/exception/AgendaErrorCode.java
+++ b/src/main/java/com/jolupbisang/demo/application/agenda/exception/AgendaErrorCode.java
@@ -9,9 +9,9 @@ public enum AgendaErrorCode implements ErrorCode {
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "권한이 없는 사용자입니다."),
     MEETING_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 회의입니다."),
     CANNOT_ADD_AGENDA(HttpStatus.BAD_REQUEST, "완료되었거나 취소된 회의에는 안건을 추가할 수 없습니다."),
-    CANNOT_DELETE_AGENDA(HttpStatus.BAD_REQUEST, "대기 중인 회의에서만 안건을 삭제할 수 있습니다."), 
-    NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 안건입니다.")
-    ;
+    CANNOT_DELETE_AGENDA(HttpStatus.BAD_REQUEST, "대기 중인 회의에서만 안건을 삭제할 수 있습니다."),
+    NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 안건입니다."),
+    CANNOT_UPDATE_AGENDA(HttpStatus.BAD_REQUEST, "대기 중인 회의에서만 안건을 수정할 수 있습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/jolupbisang/demo/application/agenda/service/AgendaService.java
+++ b/src/main/java/com/jolupbisang/demo/application/agenda/service/AgendaService.java
@@ -3,14 +3,20 @@ package com.jolupbisang.demo.application.agenda.service;
 import com.jolupbisang.demo.application.agenda.dto.AgendaDetail;
 import com.jolupbisang.demo.application.agenda.exception.AgendaErrorCode;
 import com.jolupbisang.demo.application.common.MeetingAccessValidator;
+import com.jolupbisang.demo.application.common.MeetingSessionManager;
+import com.jolupbisang.demo.application.event.AgendaChangedEvent;
 import com.jolupbisang.demo.domain.agenda.Agenda;
 import com.jolupbisang.demo.domain.meeting.Meeting;
 import com.jolupbisang.demo.global.exception.CustomException;
 import com.jolupbisang.demo.infrastructure.agenda.AgendaRepository;
 import com.jolupbisang.demo.infrastructure.meeting.MeetingRepository;
+import com.jolupbisang.demo.presentation.audio.dto.response.SocketResponseType;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
 
 import java.util.List;
 
@@ -19,7 +25,10 @@ import java.util.List;
 public class AgendaService {
     private final AgendaRepository agendaRepository;
     private final MeetingRepository meetingRepository;
+
     private final MeetingAccessValidator meetingAccessValidator;
+    private final ApplicationEventPublisher eventPublisher;
+    private final MeetingSessionManager sessionManager;
 
     @Transactional
     public boolean changeAgendaStatus(Long agendaId, Long userId, boolean isCompleted) {
@@ -27,6 +36,7 @@ public class AgendaService {
                 .orElseThrow(() -> new CustomException(AgendaErrorCode.UNAUTHORIZED));
 
         agenda.setIsCompleted(isCompleted);
+        eventPublisher.publishEvent(new AgendaChangedEvent(agenda, agenda.getMeeting()));
 
         return agenda.getIsCompleted();
     }
@@ -87,5 +97,10 @@ public class AgendaService {
         }
 
         agendaRepository.delete(agenda);
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void sendToParticipants(AgendaChangedEvent event) {
+        sessionManager.sendTextToParticipants(SocketResponseType.AGENDA_UPDATED, event.meeting().getId(), AgendaDetail.fromEntity(event.agenda()));
     }
 }

--- a/src/main/java/com/jolupbisang/demo/application/agenda/service/AgendaService.java
+++ b/src/main/java/com/jolupbisang/demo/application/agenda/service/AgendaService.java
@@ -59,6 +59,22 @@ public class AgendaService {
     }
 
     @Transactional
+    public long updateByAgendaId(Long agendaId, Long userId, String content) {
+        Agenda agenda = agendaRepository.findById(agendaId)
+                .orElseThrow(() -> new CustomException(AgendaErrorCode.NOT_FOUND));
+
+        meetingAccessValidator.validateUserIsHost(agenda.getMeeting().getId(), userId);
+
+        if (!agenda.getMeeting().isWaiting()) {
+            throw new CustomException(AgendaErrorCode.CANNOT_UPDATE_AGENDA);
+        }
+
+        agenda.updateContent(content);
+
+        return agenda.getId();
+    }
+
+    @Transactional
     public void deleteAgenda(Long agendaId, Long userId) {
         Agenda agenda = agendaRepository.findById(agendaId)
                 .orElseThrow(() -> new CustomException(AgendaErrorCode.NOT_FOUND));

--- a/src/main/java/com/jolupbisang/demo/application/agenda/service/AgendaService.java
+++ b/src/main/java/com/jolupbisang/demo/application/agenda/service/AgendaService.java
@@ -42,7 +42,7 @@ public class AgendaService {
     }
 
     @Transactional
-    public long addAgenda(Long meetingId, Long userId, String content) {
+    public long addByMeetingId(Long meetingId, Long userId, String content) {
         meetingAccessValidator.validateUserIsHost(meetingId, userId);
 
         Meeting meeting = meetingRepository.findById(meetingId)
@@ -75,7 +75,7 @@ public class AgendaService {
     }
 
     @Transactional
-    public void deleteAgenda(Long agendaId, Long userId) {
+    public void deleteById(Long agendaId, Long userId) {
         Agenda agenda = agendaRepository.findById(agendaId)
                 .orElseThrow(() -> new CustomException(AgendaErrorCode.NOT_FOUND));
         Meeting meeting = agenda.getMeeting();

--- a/src/main/java/com/jolupbisang/demo/application/event/AgendaChangedEvent.java
+++ b/src/main/java/com/jolupbisang/demo/application/event/AgendaChangedEvent.java
@@ -1,0 +1,10 @@
+package com.jolupbisang.demo.application.event;
+
+import com.jolupbisang.demo.domain.agenda.Agenda;
+import com.jolupbisang.demo.domain.meeting.Meeting;
+
+public record AgendaChangedEvent(
+        Agenda agenda,
+        Meeting meeting
+) {
+}

--- a/src/main/java/com/jolupbisang/demo/domain/agenda/Agenda.java
+++ b/src/main/java/com/jolupbisang/demo/domain/agenda/Agenda.java
@@ -32,4 +32,8 @@ public class Agenda {
     public void setIsCompleted(boolean isCompleted) {
         this.isCompleted = isCompleted;
     }
+
+    public void updateContent(String content) {
+        this.content = content;
+    }
 }

--- a/src/main/java/com/jolupbisang/demo/domain/user/User.java
+++ b/src/main/java/com/jolupbisang/demo/domain/user/User.java
@@ -2,7 +2,6 @@ package com.jolupbisang.demo.domain.user;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -26,7 +25,6 @@ public class User {
     @Enumerated(EnumType.STRING)
     private OAuthPlatform platform;
 
-    @Builder
     public User(String email, String nickname, OAuthPlatform platform) {
         this.email = email;
         this.nickname = nickname;

--- a/src/main/java/com/jolupbisang/demo/domain/user/User.java
+++ b/src/main/java/com/jolupbisang/demo/domain/user/User.java
@@ -3,6 +3,7 @@ package com.jolupbisang.demo.domain.user;
 import com.jolupbisang.demo.domain.common.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -26,6 +27,7 @@ public class User extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private OAuthPlatform platform;
 
+    @Builder
     public User(String email, String nickname, OAuthPlatform platform) {
         this.email = email;
         this.nickname = nickname;

--- a/src/main/java/com/jolupbisang/demo/domain/user/User.java
+++ b/src/main/java/com/jolupbisang/demo/domain/user/User.java
@@ -1,5 +1,6 @@
 package com.jolupbisang.demo.domain.user;
 
+import com.jolupbisang.demo.domain.common.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -9,7 +10,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "user")
 @Entity
-public class User {
+public class User extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/jolupbisang/demo/presentation/agenda/AgendaController.java
+++ b/src/main/java/com/jolupbisang/demo/presentation/agenda/AgendaController.java
@@ -6,6 +6,7 @@ import com.jolupbisang.demo.infrastructure.auth.security.CustomUserDetails;
 import com.jolupbisang.demo.presentation.agenda.api.AgendaControllerApi;
 import com.jolupbisang.demo.presentation.agenda.dto.request.AgendaCreateReq;
 import com.jolupbisang.demo.presentation.agenda.dto.request.AgendaStatusReq;
+import com.jolupbisang.demo.presentation.agenda.dto.request.AgendaUpdateReq;
 import com.jolupbisang.demo.presentation.agenda.dto.response.AgendaChangeStatusRes;
 import com.jolupbisang.demo.presentation.agenda.dto.response.AgendaCreateRes;
 import com.jolupbisang.demo.presentation.agenda.dto.response.AgendaDetailRes;
@@ -23,7 +24,7 @@ public class AgendaController implements AgendaControllerApi {
     private final AgendaService agendaService;
 
     @Override
-    @PatchMapping("/agendas/{agendaId}")
+    @PatchMapping("/agendas/status{agendaId}")
     public ResponseEntity<?> changeAgendaStatus(@RequestBody @Valid AgendaStatusReq agendaStatusReq,
                                                 @PathVariable("agendaId") Long agendaId,
                                                 @AuthenticationPrincipal CustomUserDetails customUserDetails) {
@@ -53,6 +54,17 @@ public class AgendaController implements AgendaControllerApi {
         AgendaCreateRes response = AgendaCreateRes.of(agendaId);
 
         return ResponseEntity.status(HttpStatus.CREATED).body(SuccessResponse.of("회의 안건 추가 성공", response));
+    }
+
+    @Override
+    @PatchMapping("/agendas/content/{agendaId}")
+    public ResponseEntity<?> updateAgenda(@PathVariable("agendaId") Long agendaId,
+                                          @RequestBody @Valid AgendaUpdateReq agendaUpdateReq,
+                                          @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+
+        long updatedAgendaId = agendaService.updateByAgendaId(agendaId, customUserDetails.getUserId(), agendaUpdateReq.content());
+
+        return ResponseEntity.status(HttpStatus.OK).body(SuccessResponse.of("회의 안건 수정 성공", updatedAgendaId));
     }
 
     @DeleteMapping("/agendas/{agendaId}")

--- a/src/main/java/com/jolupbisang/demo/presentation/agenda/AgendaController.java
+++ b/src/main/java/com/jolupbisang/demo/presentation/agenda/AgendaController.java
@@ -49,7 +49,7 @@ public class AgendaController implements AgendaControllerApi {
                                        @RequestBody @Valid AgendaCreateReq agendaCreateReq,
                                        @AuthenticationPrincipal CustomUserDetails customUserDetails) {
 
-        Long agendaId = agendaService.addAgenda(meetingId, customUserDetails.getUserId(), agendaCreateReq.content());
+        Long agendaId = agendaService.addByMeetingId(meetingId, customUserDetails.getUserId(), agendaCreateReq.content());
 
         AgendaCreateRes response = AgendaCreateRes.of(agendaId);
 
@@ -71,7 +71,7 @@ public class AgendaController implements AgendaControllerApi {
     public ResponseEntity<?> deleteAgenda(@PathVariable("agendaId") Long agendaId,
                                           @AuthenticationPrincipal CustomUserDetails customUserDetails) {
 
-        agendaService.deleteAgenda(agendaId, customUserDetails.getUserId());
+        agendaService.deleteById(agendaId, customUserDetails.getUserId());
 
         return ResponseEntity.status(HttpStatus.OK).body(SuccessResponse.of("회의 안건 삭제 성공", null));
     }

--- a/src/main/java/com/jolupbisang/demo/presentation/agenda/AgendaController.java
+++ b/src/main/java/com/jolupbisang/demo/presentation/agenda/AgendaController.java
@@ -24,7 +24,7 @@ public class AgendaController implements AgendaControllerApi {
     private final AgendaService agendaService;
 
     @Override
-    @PatchMapping("/agendas/status{agendaId}")
+    @PatchMapping("/agendas/status/{agendaId}")
     public ResponseEntity<?> changeAgendaStatus(@RequestBody @Valid AgendaStatusReq agendaStatusReq,
                                                 @PathVariable("agendaId") Long agendaId,
                                                 @AuthenticationPrincipal CustomUserDetails customUserDetails) {

--- a/src/main/java/com/jolupbisang/demo/presentation/agenda/api/AgendaControllerApi.java
+++ b/src/main/java/com/jolupbisang/demo/presentation/agenda/api/AgendaControllerApi.java
@@ -3,6 +3,7 @@ package com.jolupbisang.demo.presentation.agenda.api;
 import com.jolupbisang.demo.infrastructure.auth.security.CustomUserDetails;
 import com.jolupbisang.demo.presentation.agenda.dto.request.AgendaCreateReq;
 import com.jolupbisang.demo.presentation.agenda.dto.request.AgendaStatusReq;
+import com.jolupbisang.demo.presentation.agenda.dto.request.AgendaUpdateReq;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
@@ -144,6 +145,64 @@ public interface AgendaControllerApi {
     ResponseEntity<?> addAgenda(@PathVariable("meetingId") Long meetingId,
                                 @RequestBody @Valid AgendaCreateReq agendaCreateReq,
                                 @AuthenticationPrincipal CustomUserDetails customUserDetails);
+
+    @Operation(summary = "회의 안건 수정", description = "회의 안건의 내용을 수정합니다 (대기 중인 회의에서만 가능)")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "안건 수정 성공",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "수정 성공", value = """
+                                        {
+                                            "message": "회의 안건 수정 성공",
+                                            "data": null
+                                        }
+                                    """),
+                    })),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 (대기 중인 회의가 아님)",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "수정 실패 - 대기 중인 회의가 아님", value = """
+                                        {
+                                            "message": "대기 중인 회의에서만 안건을 수정할 수 있습니다.",
+                                            "errorId": "57c477a2-8201-408d-b4ac-3c664daa08f0",
+                                            "errors": null
+                                        }
+                                    """),
+                    })),
+            @ApiResponse(responseCode = "403", description = "권한 없음 (호스트가 아님)",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "수정 실패 - 권한 없음", value = """
+                                        {
+                                            "message": "해당 작업은 회의 리더만 수행할 수 있습니다.",
+                                            "errorId": "e6a96ddf-4a50-40fe-9c52-07649a1cca9f",
+                                            "errors": null
+                                        }
+                                    """),
+                    })),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 안건",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "수정 실패 - 존재하지 않는 안건", value = """
+                                        {
+                                            "message": "존재하지 않는 안건입니다.",
+                                            "errorId": "816bc13a-a4e8-420c-a70e-2274f2f8fba3",
+                                            "errors": null
+                                        }
+                                    """),
+                    })),
+            @ApiResponse(responseCode = "422", description = "DTO 검증 실패",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "수정 실패 - DTO 검증 실패", value = """
+                                        {
+                                            "message": "잘못된 입력입니다.",
+                                            "errorId": "c8c38050-d2d7-431f-93f9-4280413d9006",
+                                            "errors": {
+                                                "content": "안건 내용은 필수입니다."
+                                            }
+                                        }
+                                    """),
+                    }))
+    })
+    ResponseEntity<?> updateAgenda(@PathVariable("agendaId") Long agendaId,
+                                   @RequestBody @Valid AgendaUpdateReq agendaUpdateReq,
+                                   @AuthenticationPrincipal CustomUserDetails customUserDetails);
 
     @Operation(summary = "회의 안건 삭제", description = "회의 안건을 삭제합니다 (대기 중인 회의에서만 가능)")
     @ApiResponses(value = {

--- a/src/main/java/com/jolupbisang/demo/presentation/agenda/dto/request/AgendaUpdateReq.java
+++ b/src/main/java/com/jolupbisang/demo/presentation/agenda/dto/request/AgendaUpdateReq.java
@@ -1,0 +1,12 @@
+package com.jolupbisang.demo.presentation.agenda.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+@Schema(description = "회의 안건 수정 요청")
+public record AgendaUpdateReq(
+        @Schema(description = "수정할 안건 내용", example = "수정된 프로젝트 진행 상황 논의", requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotBlank(message = "안건 내용은 필수입니다.")
+        String content
+) {
+} 

--- a/src/main/java/com/jolupbisang/demo/presentation/audio/dto/response/SocketResponseType.java
+++ b/src/main/java/com/jolupbisang/demo/presentation/audio/dto/response/SocketResponseType.java
@@ -9,4 +9,5 @@ public enum SocketResponseType {
     COMPLETION_SCHEDULED,
     MEETING_COMPLETED,
     CONNECTION_ESTABLISHED,
+    AGENDA_UPDATED,
 } 


### PR DESCRIPTION
## 구현기능
- 아젠다 수정 기능 (리더만 가능)
    - 아젠다 상태 변경 요청 url이 수정되었음 
- 아젠다 상태 변환시 알림 기능 추가
    - Websocket을 통해 전달

## 테스트


| 테스트      | 하위항목       | 이미지                                                                                                                                                    |
| -------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
| 상태변환시 알림 | 성공         | <img width="931" alt="0시43분3초 am 2025-06-07 오후 6 27 19" src="https://github.com/user-attachments/assets/b279f475-28b6-4974-9cb5-56fcd338a4aa" /> |
| 아젠다 수정   | 수정 성공      | <img width="937" alt="0시43분3초 am 2025-06-07 오후 6 29 59" src="https://github.com/user-attachments/assets/2f5d9854-4127-43e9-a40c-0d3bde103d7f" /> |
|          | dto 검증 실패  | <img width="930" alt="0시43분3초 am 2025-06-07 오후 6 30 23" src="https://github.com/user-attachments/assets/fab6dc69-e607-4780-aacc-0deb32670b2c" /> |
|          | 존재하지 않는 안건 | <img width="930" alt="0시43분3초 am 2025-06-07 오후 6 30 35" src="https://github.com/user-attachments/assets/e7188e82-2e7d-45d3-816e-e2afff16097a" /> |
|          | 권한 없음      | <img width="935" alt="0시43분3초 am 2025-06-07 오후 6 30 47" src="https://github.com/user-attachments/assets/d9ff5587-50bb-492b-9dce-f7fbcf895c8a" /> |
|          | 대기중 아님     | <img width="933" alt="0시43분3초 am 2025-06-07 오후 6 30 12" src="https://github.com/user-attachments/assets/78d2a56b-be92-43f6-9194-9c6a62762ef0" /> |
