### PR TITLE
feat: 병합된 오디오 조회 및 회의 종료 루틴 정리

### DIFF
--- a/src/main/java/com/jolupbisang/demo/application/audio/dto/AudioListResponse.java
+++ b/src/main/java/com/jolupbisang/demo/application/audio/dto/AudioListResponse.java
@@ -1,0 +1,12 @@
+package com.jolupbisang.demo.application.audio.dto;
+
+import java.util.List;
+
+public record AudioListResponse(
+        List<AudioInfo> audioList
+) {
+    public record AudioInfo(
+            Long userId,
+            String presignedUrl
+    ) {}
+} 

--- a/src/main/java/com/jolupbisang/demo/application/audio/service/AudioService.java
+++ b/src/main/java/com/jolupbisang/demo/application/audio/service/AudioService.java
@@ -126,7 +126,7 @@ public class AudioService {
         List<AudioListResponse.AudioInfo> audioInfoList = completedUserIds.stream()
                 .map(completedUserId -> {
                     String presignedUrl = audioRepository.findCompletedURLByMeetingIdAndUserId(
-                            meetingId, completedUserId, Duration.ofHours(1));
+                            meetingId, completedUserId, Duration.ofDays(1));
                     return new AudioListResponse.AudioInfo(completedUserId, presignedUrl);
                 })
                 .toList();

--- a/src/main/java/com/jolupbisang/demo/application/audio/service/AudioService.java
+++ b/src/main/java/com/jolupbisang/demo/application/audio/service/AudioService.java
@@ -23,6 +23,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.event.EventListener;
+import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -145,6 +146,7 @@ public class AudioService {
         whisperClient.sendRefenceVector(event.getMeetingId(), users, counts, totalVectors);
     }
 
+    @Order(4)
     @EventListener
     public void handleMeetingCompletedEvent(MeetingCompletedEvent event) {
         long meetingId = event.getMeetingId();

--- a/src/main/java/com/jolupbisang/demo/application/audio/service/AudioService.java
+++ b/src/main/java/com/jolupbisang/demo/application/audio/service/AudioService.java
@@ -26,6 +26,8 @@ import org.springframework.context.event.EventListener;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.socket.BinaryMessage;
 import org.springframework.web.socket.CloseStatus;
@@ -147,7 +149,7 @@ public class AudioService {
     }
 
     @Order(4)
-    @EventListener
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleMeetingCompletedEvent(MeetingCompletedEvent event) {
         long meetingId = event.getMeetingId();
         StepFunctionOutput stepFunctionOutput = sfnClientUtil.startMergeAudioStateMachine(MERGE_AUDIO_STATE_MACHINE_ARN, meetingId);

--- a/src/main/java/com/jolupbisang/demo/application/audio/service/AudioService.java
+++ b/src/main/java/com/jolupbisang/demo/application/audio/service/AudioService.java
@@ -19,6 +19,7 @@ import com.jolupbisang.demo.infrastructure.meeting.audio.AudioProgressRepository
 import com.jolupbisang.demo.infrastructure.meeting.audio.AudioRepository;
 import com.jolupbisang.demo.infrastructure.meeting.client.WhisperClient;
 import com.jolupbisang.demo.infrastructure.meetingUser.MeetingUserRepository;
+import com.jolupbisang.demo.presentation.audio.dto.response.SocketResponseType;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -161,6 +162,7 @@ public class AudioService {
         } else {
             log.error("[StepFunction] return null");
         }
+        meetingSessionManager.sendTextToParticipants(SocketResponseType.MEETING_NOTE_CREATED, meetingId, "회의록 생성이 완료되었습니다.");
     }
 
     @EventListener

--- a/src/main/java/com/jolupbisang/demo/application/common/MeetingAccessValidator.java
+++ b/src/main/java/com/jolupbisang/demo/application/common/MeetingAccessValidator.java
@@ -18,7 +18,6 @@ public class MeetingAccessValidator {
     private final MeetingRepository meetingRepository;
     private final MeetingUserRepository meetingUserRepository;
 
-    @Cacheable(value = "meetingInProgressAndUserParticipating", key = "{#meetingId, #userId}")
     public void validateMeetingInProgressAndUserParticipating(Long meetingId, Long userId) {
         Meeting meeting = meetingRepository.findById(meetingId)
                 .orElseThrow(() -> new CustomException(MeetingAccessErrorCode.NOT_FOUND));
@@ -30,7 +29,6 @@ public class MeetingAccessValidator {
         validateUserParticipating(meetingId, userId);
     }
 
-    @Cacheable(value = "userParticipating", key = "{#meetingId, #userId}")
     public void validateUserParticipating(Long meetingId, Long userId) {
         boolean isParticipant = meetingUserRepository.existsByMeetingIdAndUserIdAndStatusIn(meetingId, userId, MeetingUserStatus.ACCEPTED);
 
@@ -39,7 +37,6 @@ public class MeetingAccessValidator {
         }
     }
 
-    @Cacheable(value = "userIsHost", key = "{#meetingId, #userId}")
     public void validateUserIsHost(Long meetingId, Long userId) {
         boolean isHost = meetingUserRepository.existsByMeetingIdAndUserIdAndIsHost(meetingId, userId, true);
 
@@ -48,7 +45,6 @@ public class MeetingAccessValidator {
         }
     }
 
-    @Cacheable(value = "meetingIsInProgress", key = "#meetingId")
     public void validateMeetingIsInProgress(Long meetingId) {
         Meeting meeting = meetingRepository.findById(meetingId)
                 .orElseThrow(() -> new CustomException(MeetingAccessErrorCode.NOT_FOUND));
@@ -58,13 +54,21 @@ public class MeetingAccessValidator {
         }
     }
 
-    @Cacheable(value = "meetingIsWaiting", key = "#meetingId")
     public void validateMeetingIsWaiting(Long meetingId) {
         Meeting meeting = meetingRepository.findById(meetingId)
                 .orElseThrow(() -> new CustomException(MeetingAccessErrorCode.NOT_FOUND));
 
         if (!meeting.isWaiting()) {
             throw new CustomException(MeetingAccessErrorCode.NOT_WAITING);
+        }
+    }
+
+    public void validateMeetingIsCompleted(Long meetingId) {
+        Meeting meeting = meetingRepository.findById(meetingId)
+                .orElseThrow(() -> new CustomException(MeetingAccessErrorCode.NOT_FOUND));
+
+        if (!meeting.isCompleted()) {
+            throw new CustomException(MeetingAccessErrorCode.NOT_COMPLETED);
         }
     }
 }

--- a/src/main/java/com/jolupbisang/demo/application/common/MeetingSessionManager.java
+++ b/src/main/java/com/jolupbisang/demo/application/common/MeetingSessionManager.java
@@ -74,6 +74,7 @@ public class MeetingSessionManager {
     @Order(5)
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void closeSessionWhenMeetingEnded(MeetingCompletedEvent event) {
+        List<WebSocketSession> sessionsToClose = new ArrayList<>();
         sessions.entrySet().stream().filter(entry -> entry.getValue().meetingId().equals(event.getMeetingId()))
                 .forEach(entry -> {
                     try {
@@ -81,10 +82,10 @@ public class MeetingSessionManager {
                     } catch (IOException e) {
                         log.error("[WebSocketSession] session close error", e);
                     } finally {
-                        sessions.remove(entry.getKey());
+                        sessionsToClose.add(entry.getKey());
                     }
                 });
-
+        sessionsToClose.forEach(sessions::remove);
     }
 
     public void sendTextToParticipants(SocketResponseType type, long meetingId, Object data) {

--- a/src/main/java/com/jolupbisang/demo/application/common/MeetingSessionManager.java
+++ b/src/main/java/com/jolupbisang/demo/application/common/MeetingSessionManager.java
@@ -6,9 +6,10 @@ import com.jolupbisang.demo.presentation.audio.dto.response.SocketResponse;
 import com.jolupbisang.demo.presentation.audio.dto.response.SocketResponseType;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.context.event.EventListener;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
 import org.springframework.web.socket.TextMessage;
 import org.springframework.web.socket.WebSocketSession;
 
@@ -71,7 +72,7 @@ public class MeetingSessionManager {
     }
 
     @Order(5)
-    @EventListener
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void closeSessionWhenMeetingEnded(MeetingCompletedEvent event) {
         sessions.entrySet().stream().filter(entry -> entry.getValue().meetingId().equals(event.getMeetingId()))
                 .forEach(entry -> {

--- a/src/main/java/com/jolupbisang/demo/application/common/exception/MeetingAccessErrorCode.java
+++ b/src/main/java/com/jolupbisang/demo/application/common/exception/MeetingAccessErrorCode.java
@@ -12,7 +12,8 @@ public enum MeetingAccessErrorCode implements ErrorCode {
     NOT_WAITING(HttpStatus.BAD_REQUEST, "대기중인 회의가 아닙니다."),
     NOT_IN_PROGRESS(HttpStatus.BAD_REQUEST, "진행중인 회의가 아닙니다."),
     NOT_PARTICIPANT(HttpStatus.FORBIDDEN, "해당 회의의 참여자가 아닙니다."),
-    NOT_LEADER(HttpStatus.FORBIDDEN, "해당 작업은 회의 리더만 수행할 수 있습니다.");
+    NOT_LEADER(HttpStatus.FORBIDDEN, "해당 작업은 회의 리더만 수행할 수 있습니다."),
+    NOT_COMPLETED(HttpStatus.FORBIDDEN, "완료된 회의가 아닙니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/jolupbisang/demo/application/context/service/ContextService.java
+++ b/src/main/java/com/jolupbisang/demo/application/context/service/ContextService.java
@@ -15,6 +15,8 @@ import org.springframework.core.annotation.Order;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -50,7 +52,7 @@ public class ContextService {
     }
 
     @Order(1)
-    @EventListener
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleMeetingCompletion(MeetingCompletedEvent event) {
         Long meetingId = event.getMeetingId();
         ScheduledFuture<?> scheduledFuture = scheduledTasks.get(meetingId);

--- a/src/main/java/com/jolupbisang/demo/application/context/service/ContextService.java
+++ b/src/main/java/com/jolupbisang/demo/application/context/service/ContextService.java
@@ -2,18 +2,23 @@ package com.jolupbisang.demo.application.context.service;
 
 import com.jolupbisang.demo.application.event.*;
 import com.jolupbisang.demo.application.event.whisper.WhisperContextEvent;
+import com.jolupbisang.demo.application.event.whisper.WhisperDiarizedEvent;
 import com.jolupbisang.demo.infrastructure.meeting.client.WhisperClient;
 import com.jolupbisang.demo.infrastructure.meeting.client.dto.response.ContextResponse;
+import com.jolupbisang.demo.infrastructure.meeting.client.dto.response.DiarizedResponse;
+import com.jolupbisang.demo.infrastructure.meeting.client.dto.response.WhisperResponseType;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.event.EventListener;
+import org.springframework.core.annotation.Order;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -44,7 +49,7 @@ public class ContextService {
         scheduledTasks.put(meetingId, scheduledFuture);
     }
 
-    @Async
+    @Order(1)
     @EventListener
     public void handleMeetingCompletion(MeetingCompletedEvent event) {
         Long meetingId = event.getMeetingId();
@@ -85,59 +90,59 @@ public class ContextService {
      * 테스트용 스케줄러입니다. 주석을 풀고 싶으시면 시작후 1분마다 피드백과 중간요약을 제공합니다.
      * userId 부분을 꼭 자기의 userId로 바꾸고 실행해야합니다!!
      */
-//    @Async("AsyncTaskExecutor")
-//    @EventListener
-//    public void makeTestTask(MeetingStartingEvent event) {
-//        long meetingId = event.getMeetingId();
-//        long userId = 1L;
-//        final int[] orderCounter = {0};
-//        final int[] currentWordStartTime = {16000};
-//
-//        Runnable task1 = () -> {
-//            log.info("This is test - publishing DiarizedEvent with incrementing order");
-//            eventPublisher.publishEvent(new SummaryReceivedEvent(this, meetingId, "Test summary", false));
-//            eventPublisher.publishEvent(new FeedbackReceivedEvent(this, meetingId, userId, "Test feedback"));
-//        };
-//
-//        Runnable task2 = () -> {
-//            int currentWordStart = currentWordStartTime[0];
-//            DiarizedResponse.Word testWord = new DiarizedResponse.Word(
-//                    currentWordStart,
-//                    currentWordStart + 1000,
-//                    "test_word",
-//                    "ko"
-//            );
-//            currentWordStartTime[0] = currentWordStart + 16000; // Increment global counter
-//
-//            DiarizedResponse.Segment completedSegment = new DiarizedResponse.Segment(
-//                    orderCounter[0],
-//                    List.of("ko"),
-//                    "그쵸 아마 이 질문의 의도는 제 생각하기에 높은 산곡대기로 가면 어쨌든 그 고도만큼 올라가니까 그렇긴 하겠네요.",
-//                    List.of(testWord),
-//                    1L,
-//                    1L
-//            );
-//            List<DiarizedResponse.Segment> completedList = new ArrayList<>();
-//            completedList.add(completedSegment);
-//
-//            DiarizedResponse.Segment candidateSegment1 = new DiarizedResponse.Segment(
-//                    orderCounter[0]++,
-//                    List.of("ko"),
-//                    "지표면에서에 비해서는 중력을 더 약하게 느끼지 않겠냐 그러면 지구 중력을 벗어나려고 결국에 연료를.",
-//                    List.of(testWord),
-//                    1L,
-//                    1L
-//            );
-//            List<DiarizedResponse.Segment> candidateList = new ArrayList<>();
-//            candidateList.add(candidateSegment1);
-//
-//            DiarizedResponse diarizedResponseForTest = new DiarizedResponse(WhisperResponseType.DIARIZED, meetingId, completedList, candidateList);
-//
-//            eventPublisher.publishEvent(new WhisperDiarizedEvent(diarizedResponseForTest));
-//        };
-//
-//        taskScheduler.scheduleAtFixedRate(task1, Instant.now().plusSeconds(10), Duration.ofMinutes(1));
-//        taskScheduler.scheduleAtFixedRate(task2, Instant.now().plusSeconds(1), Duration.ofSeconds(1));
-//    }
+    @Async("AsyncTaskExecutor")
+    @EventListener
+    public void makeTestTask(MeetingStartingEvent event) {
+        long meetingId = event.getMeetingId();
+        long userId = 1L;
+        final int[] orderCounter = {0};
+        final int[] currentWordStartTime = {16000};
+
+        Runnable task1 = () -> {
+            log.info("This is test - publishing DiarizedEvent with incrementing order");
+            eventPublisher.publishEvent(new SummaryReceivedEvent(this, meetingId, "Test summary", false));
+            eventPublisher.publishEvent(new FeedbackReceivedEvent(this, meetingId, userId, "Test feedback"));
+        };
+
+        Runnable task2 = () -> {
+            int currentWordStart = currentWordStartTime[0];
+            DiarizedResponse.Word testWord = new DiarizedResponse.Word(
+                    currentWordStart,
+                    currentWordStart + 1000,
+                    "test_word",
+                    "ko"
+            );
+            currentWordStartTime[0] = currentWordStart + 16000; // Increment global counter
+
+            DiarizedResponse.Segment completedSegment = new DiarizedResponse.Segment(
+                    orderCounter[0],
+                    List.of("ko"),
+                    "그쵸 아마 이 질문의 의도는 제 생각하기에 높은 산곡대기로 가면 어쨌든 그 고도만큼 올라가니까 그렇긴 하겠네요.",
+                    List.of(testWord),
+                    1L,
+                    1L
+            );
+            List<DiarizedResponse.Segment> completedList = new ArrayList<>();
+            completedList.add(completedSegment);
+
+            DiarizedResponse.Segment candidateSegment1 = new DiarizedResponse.Segment(
+                    orderCounter[0]++,
+                    List.of("ko"),
+                    "지표면에서에 비해서는 중력을 더 약하게 느끼지 않겠냐 그러면 지구 중력을 벗어나려고 결국에 연료를.",
+                    List.of(testWord),
+                    1L,
+                    1L
+            );
+            List<DiarizedResponse.Segment> candidateList = new ArrayList<>();
+            candidateList.add(candidateSegment1);
+
+            DiarizedResponse diarizedResponseForTest = new DiarizedResponse(WhisperResponseType.DIARIZED, meetingId, completedList, candidateList);
+
+            eventPublisher.publishEvent(new WhisperDiarizedEvent(diarizedResponseForTest));
+        };
+
+        taskScheduler.scheduleAtFixedRate(task1, Instant.now().plusSeconds(10), Duration.ofMinutes(1));
+        taskScheduler.scheduleAtFixedRate(task2, Instant.now().plusSeconds(1), Duration.ofSeconds(1));
+    }
 
 } 

--- a/src/main/java/com/jolupbisang/demo/application/context/service/ContextService.java
+++ b/src/main/java/com/jolupbisang/demo/application/context/service/ContextService.java
@@ -2,11 +2,8 @@ package com.jolupbisang.demo.application.context.service;
 
 import com.jolupbisang.demo.application.event.*;
 import com.jolupbisang.demo.application.event.whisper.WhisperContextEvent;
-import com.jolupbisang.demo.application.event.whisper.WhisperDiarizedEvent;
 import com.jolupbisang.demo.infrastructure.meeting.client.WhisperClient;
 import com.jolupbisang.demo.infrastructure.meeting.client.dto.response.ContextResponse;
-import com.jolupbisang.demo.infrastructure.meeting.client.dto.response.DiarizedResponse;
-import com.jolupbisang.demo.infrastructure.meeting.client.dto.response.WhisperResponseType;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
@@ -20,7 +17,6 @@ import org.springframework.transaction.event.TransactionalEventListener;
 
 import java.time.Duration;
 import java.time.Instant;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -92,59 +88,59 @@ public class ContextService {
      * 테스트용 스케줄러입니다. 주석을 풀고 싶으시면 시작후 1분마다 피드백과 중간요약을 제공합니다.
      * userId 부분을 꼭 자기의 userId로 바꾸고 실행해야합니다!!
      */
-    @Async("AsyncTaskExecutor")
-    @EventListener
-    public void makeTestTask(MeetingStartingEvent event) {
-        long meetingId = event.getMeetingId();
-        long userId = 1L;
-        final int[] orderCounter = {0};
-        final int[] currentWordStartTime = {16000};
-
-        Runnable task1 = () -> {
-            log.info("This is test - publishing DiarizedEvent with incrementing order");
-            eventPublisher.publishEvent(new SummaryReceivedEvent(this, meetingId, "Test summary", false));
-            eventPublisher.publishEvent(new FeedbackReceivedEvent(this, meetingId, userId, "Test feedback"));
-        };
-
-        Runnable task2 = () -> {
-            int currentWordStart = currentWordStartTime[0];
-            DiarizedResponse.Word testWord = new DiarizedResponse.Word(
-                    currentWordStart,
-                    currentWordStart + 1000,
-                    "test_word",
-                    "ko"
-            );
-            currentWordStartTime[0] = currentWordStart + 16000; // Increment global counter
-
-            DiarizedResponse.Segment completedSegment = new DiarizedResponse.Segment(
-                    orderCounter[0],
-                    List.of("ko"),
-                    "그쵸 아마 이 질문의 의도는 제 생각하기에 높은 산곡대기로 가면 어쨌든 그 고도만큼 올라가니까 그렇긴 하겠네요.",
-                    List.of(testWord),
-                    1L,
-                    1L
-            );
-            List<DiarizedResponse.Segment> completedList = new ArrayList<>();
-            completedList.add(completedSegment);
-
-            DiarizedResponse.Segment candidateSegment1 = new DiarizedResponse.Segment(
-                    orderCounter[0]++,
-                    List.of("ko"),
-                    "지표면에서에 비해서는 중력을 더 약하게 느끼지 않겠냐 그러면 지구 중력을 벗어나려고 결국에 연료를.",
-                    List.of(testWord),
-                    1L,
-                    1L
-            );
-            List<DiarizedResponse.Segment> candidateList = new ArrayList<>();
-            candidateList.add(candidateSegment1);
-
-            DiarizedResponse diarizedResponseForTest = new DiarizedResponse(WhisperResponseType.DIARIZED, meetingId, completedList, candidateList);
-
-            eventPublisher.publishEvent(new WhisperDiarizedEvent(diarizedResponseForTest));
-        };
-
-        taskScheduler.scheduleAtFixedRate(task1, Instant.now().plusSeconds(10), Duration.ofMinutes(1));
-        taskScheduler.scheduleAtFixedRate(task2, Instant.now().plusSeconds(1), Duration.ofSeconds(1));
-    }
+//    @Async("AsyncTaskExecutor")
+//    @EventListener
+//    public void makeTestTask(MeetingStartingEvent event) {
+//        long meetingId = event.getMeetingId();
+//        long userId = 1L;
+//        final int[] orderCounter = {0};
+//        final int[] currentWordStartTime = {16000};
+//
+//        Runnable task1 = () -> {
+//            log.info("This is test - publishing DiarizedEvent with incrementing order");
+//            eventPublisher.publishEvent(new SummaryReceivedEvent(this, meetingId, "Test summary", false));
+//            eventPublisher.publishEvent(new FeedbackReceivedEvent(this, meetingId, userId, "Test feedback"));
+//        };
+//
+//        Runnable task2 = () -> {
+//            int currentWordStart = currentWordStartTime[0];
+//            DiarizedResponse.Word testWord = new DiarizedResponse.Word(
+//                    currentWordStart,
+//                    currentWordStart + 1000,
+//                    "test_word",
+//                    "ko"
+//            );
+//            currentWordStartTime[0] = currentWordStart + 16000; // Increment global counter
+//
+//            DiarizedResponse.Segment completedSegment = new DiarizedResponse.Segment(
+//                    orderCounter[0],
+//                    List.of("ko"),
+//                    "그쵸 아마 이 질문의 의도는 제 생각하기에 높은 산곡대기로 가면 어쨌든 그 고도만큼 올라가니까 그렇긴 하겠네요.",
+//                    List.of(testWord),
+//                    1L,
+//                    1L
+//            );
+//            List<DiarizedResponse.Segment> completedList = new ArrayList<>();
+//            completedList.add(completedSegment);
+//
+//            DiarizedResponse.Segment candidateSegment1 = new DiarizedResponse.Segment(
+//                    orderCounter[0]++,
+//                    List.of("ko"),
+//                    "지표면에서에 비해서는 중력을 더 약하게 느끼지 않겠냐 그러면 지구 중력을 벗어나려고 결국에 연료를.",
+//                    List.of(testWord),
+//                    1L,
+//                    1L
+//            );
+//            List<DiarizedResponse.Segment> candidateList = new ArrayList<>();
+//            candidateList.add(candidateSegment1);
+//
+//            DiarizedResponse diarizedResponseForTest = new DiarizedResponse(WhisperResponseType.DIARIZED, meetingId, completedList, candidateList);
+//
+//            eventPublisher.publishEvent(new WhisperDiarizedEvent(diarizedResponseForTest));
+//        };
+//
+//        taskScheduler.scheduleAtFixedRate(task1, Instant.now().plusSeconds(10), Duration.ofMinutes(1));
+//        taskScheduler.scheduleAtFixedRate(task2, Instant.now().plusSeconds(1), Duration.ofSeconds(1));
+//    }
 
 } 

--- a/src/main/java/com/jolupbisang/demo/application/participationRate/ParticipationRateService.java
+++ b/src/main/java/com/jolupbisang/demo/application/participationRate/ParticipationRateService.java
@@ -25,6 +25,8 @@ import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.time.Duration;
@@ -100,7 +102,7 @@ public class ParticipationRateService {
     }
 
     @Order(2)
-    @EventListener
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void clearMeetingData(MeetingCompletedEvent event) {
         Long meetingId = event.getMeetingId();
 

--- a/src/main/java/com/jolupbisang/demo/application/participationRate/ParticipationRateService.java
+++ b/src/main/java/com/jolupbisang/demo/application/participationRate/ParticipationRateService.java
@@ -20,6 +20,7 @@ import com.jolupbisang.demo.infrastructure.user.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.event.EventListener;
+import org.springframework.core.annotation.Order;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
@@ -98,7 +99,7 @@ public class ParticipationRateService {
         scheduledTasks.put(meetingId, scheduledFuture);
     }
 
-    @Async
+    @Order(2)
     @EventListener
     public void clearMeetingData(MeetingCompletedEvent event) {
         Long meetingId = event.getMeetingId();

--- a/src/main/java/com/jolupbisang/demo/application/summary/SummaryService.java
+++ b/src/main/java/com/jolupbisang/demo/application/summary/SummaryService.java
@@ -21,6 +21,8 @@ import org.springframework.core.annotation.Order;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.time.Instant;
@@ -75,7 +77,7 @@ public class SummaryService {
     }
 
     @Order(3)
-    @EventListener
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void createWholeSummary(MeetingCompletedEvent event) {
         whisperClient.sendContextDone(event.getMeetingId());
     }

--- a/src/main/java/com/jolupbisang/demo/application/summary/SummaryService.java
+++ b/src/main/java/com/jolupbisang/demo/application/summary/SummaryService.java
@@ -17,6 +17,7 @@ import com.jolupbisang.demo.infrastructure.summary.SummaryRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.event.EventListener;
+import org.springframework.core.annotation.Order;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
@@ -73,6 +74,7 @@ public class SummaryService {
         meetingSseService.sendEventToMeeting(String.valueOf(meetingId), MeetingSseEventType.SUMMARY, SseSummaryRes.of(timestamp, summary));
     }
 
+    @Order(3)
     @EventListener
     public void createWholeSummary(MeetingCompletedEvent event) {
         whisperClient.sendContextDone(event.getMeetingId());

--- a/src/main/java/com/jolupbisang/demo/global/config/AWSConfig.java
+++ b/src/main/java/com/jolupbisang/demo/global/config/AWSConfig.java
@@ -9,6 +9,7 @@ import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.http.apache.ApacheHttpClient;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.services.sfn.SfnClient;
 
 import java.time.Duration;
@@ -44,6 +45,19 @@ public class AWSConfig {
         AwsBasicCredentials credentials = AwsBasicCredentials.create(accessKey, secretKey);
 
         return S3Client.builder()
+                .region(Region.of(region))
+                .credentialsProvider(StaticCredentialsProvider.create(credentials))
+                .build();
+    }
+
+    @Bean
+    public S3Presigner s3Presigner() {
+        String region = awsProperties.getRegion();
+        String accessKey = awsProperties.getCredentials().getAccessKey();
+        String secretKey = awsProperties.getCredentials().getSecretKey();
+        AwsBasicCredentials credentials = AwsBasicCredentials.create(accessKey, secretKey);
+
+        return S3Presigner.builder()
                 .region(Region.of(region))
                 .credentialsProvider(StaticCredentialsProvider.create(credentials))
                 .build();

--- a/src/main/java/com/jolupbisang/demo/infrastructure/meeting/audio/AudioRepository.java
+++ b/src/main/java/com/jolupbisang/demo/infrastructure/meeting/audio/AudioRepository.java
@@ -4,8 +4,14 @@ import com.jolupbisang.demo.application.audio.dto.AudioMeta;
 import org.springframework.stereotype.Repository;
 
 import java.io.IOException;
+import java.time.Duration;
+import java.util.List;
 
 @Repository
 public interface AudioRepository {
     String save(AudioMeta audioMeta, byte[] audioData) throws IOException;
+
+    String findCompletedURLByMeetingIdAndUserId(long meetingId, long userId, Duration duration);
+    
+    List<Long> findCompletedUserIdsByMeetingId(long meetingId);
 }

--- a/src/main/java/com/jolupbisang/demo/infrastructure/meeting/audio/AudioRepositoryImpl.java
+++ b/src/main/java/com/jolupbisang/demo/infrastructure/meeting/audio/AudioRepositoryImpl.java
@@ -49,7 +49,7 @@ public class AudioRepositoryImpl implements AudioRepository {
     public String findCompletedURLByMeetingIdAndUserId(long meetingId, long userId, Duration duration) {
         return s3ClientUtil.generatePresignedUrl(
                 generateS3CompletedURLKey(meetingId, userId),
-                Duration.ofDays(1)
+                duration
         );
     }
 
@@ -57,9 +57,9 @@ public class AudioRepositoryImpl implements AudioRepository {
     public List<Long> findCompletedUserIdsByMeetingId(long meetingId) {
         String prefix = String.format("merged-audio/meeting-%d/", meetingId);
         List<String> objectKeys = s3ClientUtil.listObjectKeysByPrefix(prefix);
-        
+
         Pattern userIdPattern = Pattern.compile("merged-audio/meeting-\\d+/user-(\\d+)/");
-        
+
         return objectKeys.stream()
                 .map(userIdPattern::matcher)
                 .filter(Matcher::find)

--- a/src/main/java/com/jolupbisang/demo/presentation/audio/AudioController.java
+++ b/src/main/java/com/jolupbisang/demo/presentation/audio/AudioController.java
@@ -1,6 +1,7 @@
 package com.jolupbisang.demo.presentation.audio;
 
 
+import com.jolupbisang.demo.application.audio.dto.AudioListResponse;
 import com.jolupbisang.demo.application.audio.service.AudioService;
 import com.jolupbisang.demo.global.response.SuccessResponse;
 import com.jolupbisang.demo.infrastructure.auth.security.CustomUserDetails;
@@ -9,6 +10,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestPart;
@@ -21,6 +24,7 @@ import org.springframework.web.multipart.MultipartFile;
 public class AudioController implements AudioControllerApi {
     private final AudioService audioService;
 
+    @Override
     @PostMapping(value = "/embedding", consumes = "multipart/form-data")
     public ResponseEntity<?> embeddingAudio(@RequestPart("audioFile") MultipartFile file,
                                             @AuthenticationPrincipal CustomUserDetails userDetails) {
@@ -28,5 +32,16 @@ public class AudioController implements AudioControllerApi {
         audioService.embeddingAudio(userDetails.getUserId(), file);
 
         return ResponseEntity.status(HttpStatus.CREATED).body(SuccessResponse.of("전송 성공", null));
+    }
+
+    @Override
+    @GetMapping("/meeting/{meetingId}")
+    public ResponseEntity<SuccessResponse<AudioListResponse>> getCompletedMeetingAudioList(
+            @PathVariable Long meetingId,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+
+        AudioListResponse audioList = audioService.getCompletedMeetingAudioList(meetingId, userDetails.getUserId());
+
+        return ResponseEntity.ok(SuccessResponse.of("오디오 목록 조회 성공", audioList));
     }
 }

--- a/src/main/java/com/jolupbisang/demo/presentation/audio/api/AudioControllerApi.java
+++ b/src/main/java/com/jolupbisang/demo/presentation/audio/api/AudioControllerApi.java
@@ -1,5 +1,7 @@
 package com.jolupbisang.demo.presentation.audio.api;
 
+import com.jolupbisang.demo.application.audio.dto.AudioListResponse;
+import com.jolupbisang.demo.global.response.SuccessResponse;
 import com.jolupbisang.demo.infrastructure.auth.security.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -9,11 +11,11 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
 
 public interface AudioControllerApi {
-
 
     @Operation(summary = "임베딩 오디오 전송", description = "목소리 인식을 위해서 임베딩 오디오를 보냅니다.")
     @ApiResponses(value = {
@@ -30,4 +32,53 @@ public interface AudioControllerApi {
     ResponseEntity<?> embeddingAudio(@RequestPart("audioFile") MultipartFile file,
                                      @Parameter(hidden = true)
                                      @AuthenticationPrincipal CustomUserDetails userDetails);
+
+    @Operation(summary = "완료된 회의 오디오 목록 조회", description = "완료된 회의의 모든 참여자 오디오 파일에 대한 presigned URL 목록을 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "오디오 목록 조회 성공",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "조회 성공", value = """
+                                        {
+                                            "message": "오디오 목록 조회 성공",
+                                            "data": {
+                                                "audioList": [
+                                                    {
+                                                        "userId": 1,
+                                                        "presignedUrl": "https://bucket-silrok.s3.ap-northeast-2.amazonaws.com..."
+                                                    },
+                                                    {
+                                                        "userId": 2,
+                                                        "presignedUrl": "https://bucket-silrok.s3.ap-northeast-2.amazonaws.com..."
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "403", description = "회의 접근 권한 없음",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "권한 없음", value = """
+                                        {
+                                            "message": "해당 회의의 참여자가 아닙니다.",
+                                            "errorId": "6b4b8956-f5a9-4d3a-9093-e8f488ca53ce",
+                                            "errors": null
+                                        }
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "400", description = "회의가 완료되지 않음",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "회의 미완료", value = """
+                                        {
+                                            "message": "완료된 회의가 아닙니다.",
+                                            "errorId": "1ec70342-d2d4-4c7d-af74-65c5a0b897bb",
+                                            "errors": null
+                                        }
+                                    """)
+                    }))
+    })
+    ResponseEntity<SuccessResponse<AudioListResponse>> getCompletedMeetingAudioList(
+            @Parameter(description = "회의 ID", required = true, example = "123")
+            @PathVariable Long meetingId,
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal CustomUserDetails userDetails);
 }

--- a/src/main/java/com/jolupbisang/demo/presentation/audio/dto/response/SocketResponseType.java
+++ b/src/main/java/com/jolupbisang/demo/presentation/audio/dto/response/SocketResponseType.java
@@ -10,4 +10,5 @@ public enum SocketResponseType {
     MEETING_COMPLETED,
     CONNECTION_ESTABLISHED,
     AGENDA_UPDATED,
+    MEETING_NOTE_CREATED,
 } 


### PR DESCRIPTION
## 구현기능
- 병합된 오디오 조회 기능 추가 (S3 presigned URL 전달)
- 회의 종료 루틴 정리 (아래의 루틴 실행)
    1. 회의 종료 처리 및 참여자들에게 전파
    2. 회의 요약, 피드백, 아젠다 요청 스케줄러 종료
    3. 참여율 집계 종료 및 데이터베이스에 저장
    4. Whispr 서버에 회의 종료요청 및 전체 요약 저장
    5. 오디오 병합
    6. 회의 참여자들에게 회의록 생성 완료 메세지 전달 및 세션 종료

## 테스트

| 테스트    | 하위항목       | 이미지                                                                                                                                                      |
| ------ | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
| 오디오 조회 | 조회 성공      | <img width="1020" alt="0시43분3초 am 2025-06-07 오후 10 41 42" src="https://github.com/user-attachments/assets/b9d7e5e8-09c8-483a-ae59-9909a17e06c2" /> |
|        | 참여자가 아님    | <img width="1015" alt="0시43분3초 am 2025-06-07 오후 10 41 55" src="https://github.com/user-attachments/assets/1dbd2535-1fef-4a14-b94e-5d486616a060" /> |
|        | 완료된 회의가 아님 | <img width="1016" alt="0시43분3초 am 2025-06-07 오후 10 42 01" src="https://github.com/user-attachments/assets/1a019a33-6dec-4e07-804b-49042f459dd5" /> |
