### PR TITLE
fix: sse 전송시 트랜잭션이 있는 경우, 트랜잭션 끝난 경우에만 전송하도록 변경

### DIFF
--- a/src/main/java/com/jolupbisang/demo/application/event/SseEmitEvent.java
+++ b/src/main/java/com/jolupbisang/demo/application/event/SseEmitEvent.java
@@ -1,0 +1,11 @@
+package com.jolupbisang.demo.application.event;
+
+import com.jolupbisang.demo.infrastructure.sse.MeetingSseEventType;
+
+public record SseEmitEvent(
+        String meetingId,
+        MeetingSseEventType type,
+        Object data
+) {
+
+}

--- a/src/main/java/com/jolupbisang/demo/application/feedback/FeedbackService.java
+++ b/src/main/java/com/jolupbisang/demo/application/feedback/FeedbackService.java
@@ -2,6 +2,7 @@ package com.jolupbisang.demo.application.feedback;
 
 import com.jolupbisang.demo.application.common.MeetingAccessValidator;
 import com.jolupbisang.demo.application.event.FeedbackReceivedEvent;
+import com.jolupbisang.demo.application.event.SseEmitEvent;
 import com.jolupbisang.demo.application.feedback.dto.FeedbackListRes;
 import com.jolupbisang.demo.application.feedback.dto.SseFeedbackRes;
 import com.jolupbisang.demo.application.feedback.exception.FeedbackErrorCode;
@@ -16,6 +17,7 @@ import com.jolupbisang.demo.infrastructure.sse.MeetingSseService;
 import com.jolupbisang.demo.infrastructure.user.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.event.EventListener;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -35,6 +37,7 @@ public class FeedbackService {
     private final FeedbackRepository feedbackRepository;
     private final MeetingRepository meetingRepository;
     private final UserRepository userRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
     private final MeetingAccessValidator meetingAccessValidator;
     private final MeetingSseService meetingSseService;
@@ -75,6 +78,6 @@ public class FeedbackService {
         }
 
         feedbackRepository.save(new Feedback(meeting, user, comment, timestamp));
-        meetingSseService.sendEventToUserOfMeeting(String.valueOf(meetingId), String.valueOf(userId), MeetingSseEventType.FEEDBACK, SseFeedbackRes.of(timestamp, comment));
+        eventPublisher.publishEvent(new SseEmitEvent(String.valueOf(meetingId), MeetingSseEventType.FEEDBACK, SseFeedbackRes.of(timestamp, comment)));
     }
 }

--- a/src/main/java/com/jolupbisang/demo/application/participationRate/ParticipationRateService.java
+++ b/src/main/java/com/jolupbisang/demo/application/participationRate/ParticipationRateService.java
@@ -22,7 +22,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.event.EventListener;
 import org.springframework.core.annotation.Order;
 import org.springframework.scheduling.TaskScheduler;
-import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionPhase;
@@ -86,7 +85,6 @@ public class ParticipationRateService {
         }
     }
 
-    @Async("AsyncTaskExecutor")
     @EventListener
     public void handleMeetingStart(MeetingStartingEvent event) {
         long meetingId = event.getMeetingId();


### PR DESCRIPTION
## 구현기능
- sse 전송시 트랜잭션을 잡아먹는 문제 해결

## 해결방법
sse 전송시 트랜잭션을 잡아먹어 DB 커넥션 고갈 문제가 있었음.
sse 전송을 위해서 메서드를 호출 -> 이벤트를 발행 -> TransactionEventListener로 트랜잭션이 완료된 후에만 실행하도록 변경
transaction을 사용하지 않는 메서드는 기존의 sse 전송 메서드를 사용함 (기존 방법)