### PR TITLE
fix: rabbitMQ로 segment 처리 기능 추가, 피드백 조회 오류 수정, 로그 파일 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,10 @@ dependencies {
     implementation 'software.amazon.awssdk:s3'
     implementation 'software.amazon.awssdk:sfn'
     implementation 'software.amazon.awssdk:apache-client'
+
+    //Messaging
+    implementation 'org.springframework.boot:spring-boot-starter-amqp'
+    
 }
 
 tasks.named('test') {

--- a/src/main/java/com/jolupbisang/demo/application/feedback/FeedbackService.java
+++ b/src/main/java/com/jolupbisang/demo/application/feedback/FeedbackService.java
@@ -51,7 +51,7 @@ public class FeedbackService {
     public Slice<FeedbackListRes> getFeedbacks(Long meetingId, Long userId, Pageable pageable) {
         meetingAccessValidator.validateUserParticipating(meetingId, userId);
 
-        Slice<Feedback> feedbacks = feedbackRepository.findByMeetingId(meetingId, pageable);
+        Slice<Feedback> feedbacks = feedbackRepository.findByMeetingIdAndUserId(meetingId, userId, pageable);
 
         return feedbacks.map(FeedbackListRes::from);
     }

--- a/src/main/java/com/jolupbisang/demo/application/segment/SegmentSaver.java
+++ b/src/main/java/com/jolupbisang/demo/application/segment/SegmentSaver.java
@@ -1,0 +1,36 @@
+package com.jolupbisang.demo.application.segment;
+
+import com.jolupbisang.demo.application.segment.dto.SegmentMessage;
+import com.jolupbisang.demo.global.config.RabbitMQConfig;
+import com.rabbitmq.client.Channel;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.amqp.support.AmqpHeaders;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SegmentSaver {
+    private final SegmentService segmentService;
+
+    @RabbitListener(queues = RabbitMQConfig.SEGMENT_QUEUE)
+    public void receiveSingleSegment(
+            SegmentMessage message,
+            Channel channel,
+            @Header(AmqpHeaders.DELIVERY_TAG) long deliveryTag
+    ) throws IOException {
+        try {
+            segmentService.saveCompletedSegment(message);
+            channel.basicAck(deliveryTag, false);
+
+        } catch (Exception e) {
+            log.error("Failed to process segment. DTO: {}. Error: {}", message, e.getMessage());
+            channel.basicNack(deliveryTag, false, false);
+        }
+    }
+}

--- a/src/main/java/com/jolupbisang/demo/application/segment/dto/SegmentMessage.java
+++ b/src/main/java/com/jolupbisang/demo/application/segment/dto/SegmentMessage.java
@@ -1,0 +1,13 @@
+package com.jolupbisang.demo.application.segment.dto;
+
+import com.jolupbisang.demo.infrastructure.audio.client.dto.response.DiarizedResponse;
+
+public record SegmentMessage(
+        long meetingId,
+        DiarizedResponse.Segment segmentData
+) {
+
+    public static SegmentMessage of(DiarizedResponse.Segment segmentData, long meetingId) {
+        return new SegmentMessage(meetingId, segmentData);
+    }
+}

--- a/src/main/java/com/jolupbisang/demo/global/config/RabbitMQConfig.java
+++ b/src/main/java/com/jolupbisang/demo/global/config/RabbitMQConfig.java
@@ -1,0 +1,63 @@
+package com.jolupbisang.demo.global.config;
+
+import org.springframework.amqp.core.*;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RabbitMQConfig {
+
+    // 상수 정의 (오타 방지 및 재사용)
+    public static final String SEGMENT_EXCHANGE = "segment.exchange";
+    public static final String SEGMENT_QUEUE = "segment.queue";
+    public static final String SEGMENT_ROUTING_KEY = "segment.create";
+
+    // Dead Letter Queue 설정 (처리 실패 메시지 이동)
+    public static final String DEAD_LETTER_EXCHANGE = "dead.order.exchange";
+    public static final String DEAD_LETTER_QUEUE = "dead.order.queue";
+    public static final String DEAD_LETTER_ROUTING_KEY = "dead.order.create";
+
+
+    // 1. Exchange (메시지 라우팅 역할) 생성
+    @Bean
+    public Exchange orderExchange() {
+        return new TopicExchange(SEGMENT_EXCHANGE, true, false); // durable: true
+    }
+
+    // 2. Queue (메시지 저장소) 생성
+    @Bean
+    public Queue orderQueue() {
+        return QueueBuilder.durable(SEGMENT_QUEUE) // durable: true
+                .withArgument("x-dead-letter-exchange", DEAD_LETTER_EXCHANGE) // 처리 실패 시 이동할 DLX
+                .withArgument("x-dead-letter-routing-key", DEAD_LETTER_ROUTING_KEY) // DLX로 보낼 때 사용할 라우팅 키
+                .build();
+    }
+
+    // 3. Binding (Exchange와 Queue 연결)
+    @Bean
+    public Binding orderBinding(Queue orderQueue, Exchange orderExchange) {
+        return BindingBuilder.bind(orderQueue)
+                .to(orderExchange)
+                .with(SEGMENT_ROUTING_KEY)
+                .noargs();
+    }
+
+    // --- Dead Letter Queue 관련 설정 ---
+    @Bean
+    public Exchange deadLetterExchange() {
+        return new TopicExchange(DEAD_LETTER_EXCHANGE, true, false);
+    }
+
+    @Bean
+    public Queue deadLetterQueue() {
+        return new Queue(DEAD_LETTER_QUEUE, true);
+    }
+
+    @Bean
+    public Binding deadLetterBinding(Queue deadLetterQueue, Exchange deadLetterExchange) {
+        return BindingBuilder.bind(deadLetterQueue)
+                .to(deadLetterExchange)
+                .with(DEAD_LETTER_ROUTING_KEY)
+                .noargs();
+    }
+}

--- a/src/main/java/com/jolupbisang/demo/infrastructure/feedback/FeedbackRepository.java
+++ b/src/main/java/com/jolupbisang/demo/infrastructure/feedback/FeedbackRepository.java
@@ -6,6 +6,5 @@ import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface FeedbackRepository extends JpaRepository<Feedback, Long> {
-    
-    Slice<Feedback> findByMeetingId(Long meetingId, Pageable pageable);
+    Slice<Feedback> findByMeetingIdAndUserId(Long meetingId, Long userId, Pageable pageable);
 }

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <property name="LOG_PATH" value="/path/to/logs"/>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${LOG_PATH}/logfile.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>${LOG_PATH}/logfile.%d{yyyy-MM-dd}.log</fileNamePattern>
+            <maxHistory>30</maxHistory>
+        </rollingPolicy>
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+        <appender-ref ref="FILE"/>
+    </root>
+
+</configuration>


### PR DESCRIPTION
## 구현기능
- 기존 Completed Segment를 받았을 때 데이터베이스에 저장하던 로직 개선
    - rabbitMQ에 푸싱하고 워커 쓰레드가 해당 메세지를 처리하는 방식으로 변경
    - 데이터베이스 커넥션 부족 해결
- 피드백 조회시 meetingId로만 조회하던 문제 해결
- 로그 파일로 추출 설정