### PR TITLE
feat: docker compose 배포 수동 트리거 추가

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,4 +1,4 @@
-name: Deploy Docker Compose Files
+name: Deploy Docker Compose
 
 on:
   push:
@@ -7,6 +7,8 @@ on:
     paths:
       - 'docker/docker-compose*.yml'
       - 'docker/docker-compose*.yaml'
+
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
## 개요
docker compose 배포를 웹에서 수동 트리거를 통해 실행할 수 있도록 변경

## 적용 이유
변경 사항이 없지만, docker compose 파일을 복사해야할 때 쉽게 이용하기 위해 추가