### PR TITLE
fix: github action이 환경변수를 해석하지 못하는 문제 해결

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -29,7 +29,7 @@ jobs:
           key: ${{ secrets.EC2_SSH_KEY }}
           script_stop: true
           script: |
-            mkdir -p /docker
+            mkdir -p "/home/ubuntu/docker"
 
       - name: Copy docker-compose to EC2
         uses: appleboy/scp-action@master
@@ -38,8 +38,8 @@ jobs:
           host: ${{ secrets.EC2_IP }}
           key: ${{ secrets.EC2_SSH_KEY }}
           source: "docker/docker-compose*.yml,docker/docker-compose*.yaml"
-          target: "~/"
-          strip_components: 0
+          target: "/home/ubuntu/docker"
+          strip_components: 1
 
       - name: Verify deployment
         uses: appleboy/ssh-action@master


### PR DESCRIPTION
## 배경
github actions에서 환경변수를 해석해서 사용하지 못함

## 작업사항
절대 경로를 기입하여 해결