### PR TITLE
feat: 팀 기능 추가

### DIFF
--- a/src/main/java/com/jolupbisang/demo/application/team/TeamCreationService.java
+++ b/src/main/java/com/jolupbisang/demo/application/team/TeamCreationService.java
@@ -1,0 +1,46 @@
+package com.jolupbisang.demo.application.team;
+
+import com.jolupbisang.demo.application.team.command.dto.TeamCreationReq;
+import com.jolupbisang.demo.application.team.command.dto.TeamCreationRes;
+import com.jolupbisang.demo.domain.team.model.Team;
+import com.jolupbisang.demo.domain.team.model.TeamName;
+import com.jolupbisang.demo.domain.user.User;
+import com.jolupbisang.demo.global.exception.NotFoundException;
+import com.jolupbisang.demo.infrastructure.team.TeamRepository;
+import com.jolupbisang.demo.infrastructure.user.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class TeamCreationService {
+
+    private final TeamRepository teamRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public TeamCreationRes create(TeamCreationReq teamCreationReq, long creatorId) {
+        if (!userRepository.existsById(creatorId)) {
+            throw new NotFoundException("팀 생성자 정보가 없습니다. creatorId: %d", creatorId);
+        }
+
+        List<User> members = userRepository.findByEmailIn(teamCreationReq.memberEmails());
+
+        List<Long> memberIds = members.stream()
+                .map(User::getId)
+                .toList();
+
+        Team team = new Team(
+                new TeamName(teamCreationReq.teamName()),
+                creatorId,
+                memberIds
+        );
+
+        Team savedTeam = teamRepository.save(team);
+
+        return new TeamCreationRes(savedTeam.getId());
+    }
+}

--- a/src/main/java/com/jolupbisang/demo/application/team/command/TeamMemberAdditionService.java
+++ b/src/main/java/com/jolupbisang/demo/application/team/command/TeamMemberAdditionService.java
@@ -1,0 +1,37 @@
+package com.jolupbisang.demo.application.team.command;
+
+import com.jolupbisang.demo.application.team.command.dto.TeamMemberAdditionReq;
+import com.jolupbisang.demo.application.team.command.dto.TeamMemberAdditionRes;
+import com.jolupbisang.demo.domain.team.model.Team;
+import com.jolupbisang.demo.domain.team.model.TeamMemberRole;
+import com.jolupbisang.demo.domain.user.User;
+import com.jolupbisang.demo.global.exception.NotFoundException;
+import com.jolupbisang.demo.infrastructure.team.TeamRepository;
+import com.jolupbisang.demo.infrastructure.user.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class TeamMemberAdditionService {
+
+    private final TeamRepository teamRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public TeamMemberAdditionRes addMember(Long teamId, Long accessUserId, TeamMemberAdditionReq request) {
+        Team team = teamRepository.findByIdWithMembers(teamId)
+                .orElseThrow(() -> new NotFoundException("teamId: %d", teamId));
+
+        team.validateOwnerAuthority(accessUserId);
+
+        User userToAdd = userRepository.findByEmail(request.memberEmail())
+                .orElseThrow(() -> new NotFoundException("이메일로 사용자를 찾을 수 없습니다. email: %s", request.memberEmail()));
+
+        team.addMember(userToAdd.getId(), TeamMemberRole.TEAM_MEMBER);
+
+        return new TeamMemberAdditionRes(team.getId());
+    }
+}
+

--- a/src/main/java/com/jolupbisang/demo/application/team/command/dto/TeamCreationReq.java
+++ b/src/main/java/com/jolupbisang/demo/application/team/command/dto/TeamCreationReq.java
@@ -1,0 +1,16 @@
+package com.jolupbisang.demo.application.team.command.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.List;
+
+public record TeamCreationReq(
+        @NotBlank(message = "팀 이름은 1글자 이상이어야 합니다.")
+        String teamName,
+
+        @NotNull(message = "멤버 목록은 필수 입니다.")
+        List<@Email(message = "멤버 이메일은 이메일 형식이어야 합니다.") String> memberEmails
+) {
+}

--- a/src/main/java/com/jolupbisang/demo/application/team/command/dto/TeamCreationRes.java
+++ b/src/main/java/com/jolupbisang/demo/application/team/command/dto/TeamCreationRes.java
@@ -1,0 +1,6 @@
+package com.jolupbisang.demo.application.team.command.dto;
+
+public record TeamCreationRes(
+        long teamId
+) {
+}

--- a/src/main/java/com/jolupbisang/demo/application/team/command/dto/TeamMemberAdditionReq.java
+++ b/src/main/java/com/jolupbisang/demo/application/team/command/dto/TeamMemberAdditionReq.java
@@ -1,0 +1,12 @@
+package com.jolupbisang.demo.application.team.command.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record TeamMemberAdditionReq(
+        @NotBlank(message = "멤버 이메일은 필수입니다.")
+        @Email(message = "올바른 이메일 형식이어야 합니다.")
+        String memberEmail
+) {
+}
+

--- a/src/main/java/com/jolupbisang/demo/application/team/command/dto/TeamMemberAdditionRes.java
+++ b/src/main/java/com/jolupbisang/demo/application/team/command/dto/TeamMemberAdditionRes.java
@@ -1,0 +1,7 @@
+package com.jolupbisang.demo.application.team.command.dto;
+
+public record TeamMemberAdditionRes(
+        long teamId
+) {
+}
+

--- a/src/main/java/com/jolupbisang/demo/application/team/query/TeamDetailQueryService.java
+++ b/src/main/java/com/jolupbisang/demo/application/team/query/TeamDetailQueryService.java
@@ -1,0 +1,27 @@
+package com.jolupbisang.demo.application.team.query;
+
+import com.jolupbisang.demo.application.team.query.dto.TeamDetailRes;
+import com.jolupbisang.demo.domain.team.model.Team;
+import com.jolupbisang.demo.global.exception.NotFoundException;
+import com.jolupbisang.demo.infrastructure.team.TeamRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class TeamDetailQueryService {
+
+    private final TeamRepository teamRepository;
+
+    @Transactional(readOnly = true)
+    public TeamDetailRes getTeamDetail(Long teamId, Long accessUserId) {
+        Team team = teamRepository.findByIdWithMembers(teamId)
+                .orElseThrow(() -> new NotFoundException("teamId: %d", teamId));
+
+        team.validateViewAuthority(accessUserId);
+
+        return TeamDetailRes.fromEntity(team);
+    }
+}
+

--- a/src/main/java/com/jolupbisang/demo/application/team/query/TeamListQueryService.java
+++ b/src/main/java/com/jolupbisang/demo/application/team/query/TeamListQueryService.java
@@ -1,0 +1,27 @@
+package com.jolupbisang.demo.application.team.query;
+
+import com.jolupbisang.demo.application.team.query.dto.TeamListRes;
+import com.jolupbisang.demo.domain.team.model.Team;
+import com.jolupbisang.demo.infrastructure.team.TeamRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class TeamListQueryService {
+
+    private final TeamRepository teamRepository;
+
+    @Transactional(readOnly = true)
+    public List<TeamListRes> getTeamsByUserId(Long userId) {
+        List<Team> teams = teamRepository.findByMembersUserId(userId);
+        
+        return teams.stream()
+                .map(TeamListRes::fromEntity)
+                .toList();
+    }
+}
+

--- a/src/main/java/com/jolupbisang/demo/application/team/query/TeamMemberQueryService.java
+++ b/src/main/java/com/jolupbisang/demo/application/team/query/TeamMemberQueryService.java
@@ -1,0 +1,38 @@
+package com.jolupbisang.demo.application.team.query;
+
+import com.jolupbisang.demo.application.team.query.dto.TeamMemberRes;
+import com.jolupbisang.demo.domain.team.model.Team;
+import com.jolupbisang.demo.domain.user.User;
+import com.jolupbisang.demo.global.exception.NotFoundException;
+import com.jolupbisang.demo.infrastructure.team.TeamRepository;
+import com.jolupbisang.demo.infrastructure.user.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class TeamMemberQueryService {
+
+    private final TeamRepository teamRepository;
+    private final UserRepository userRepository;
+
+    @Transactional(readOnly = true)
+    public TeamMemberRes getTeamMembers(Long teamId, Long accessUserId) {
+        Team team = teamRepository.findByIdWithMembers(teamId)
+                .orElseThrow(() -> new NotFoundException("teamId: %d", teamId));
+
+        team.validateViewAuthority(accessUserId);
+
+        List<Long> memberIds = team.getMembers().stream()
+                .map(member -> member.getUserId())
+                .toList();
+
+        List<User> members = userRepository.findAllById(memberIds);
+
+        return TeamMemberRes.from(members);
+    }
+}
+

--- a/src/main/java/com/jolupbisang/demo/application/team/query/dto/TeamDetailRes.java
+++ b/src/main/java/com/jolupbisang/demo/application/team/query/dto/TeamDetailRes.java
@@ -1,0 +1,16 @@
+package com.jolupbisang.demo.application.team.query.dto;
+
+import com.jolupbisang.demo.domain.team.model.Team;
+
+public record TeamDetailRes(
+        Long teamId,
+        String teamName
+) {
+    public static TeamDetailRes fromEntity(Team team) {
+        return new TeamDetailRes(
+                team.getId(),
+                team.getTeamName().getName()
+        );
+    }
+}
+

--- a/src/main/java/com/jolupbisang/demo/application/team/query/dto/TeamListRes.java
+++ b/src/main/java/com/jolupbisang/demo/application/team/query/dto/TeamListRes.java
@@ -9,7 +9,7 @@ public record TeamListRes(
     public static TeamListRes fromEntity(Team team) {
         return new TeamListRes(
                 team.getId(),
-                team.getTeamName().name()
+                team.getTeamName().getName()
         );
     }
 }

--- a/src/main/java/com/jolupbisang/demo/application/team/query/dto/TeamListRes.java
+++ b/src/main/java/com/jolupbisang/demo/application/team/query/dto/TeamListRes.java
@@ -1,0 +1,16 @@
+package com.jolupbisang.demo.application.team.query.dto;
+
+import com.jolupbisang.demo.domain.team.model.Team;
+
+public record TeamListRes(
+        Long teamId,
+        String teamName
+) {
+    public static TeamListRes fromEntity(Team team) {
+        return new TeamListRes(
+                team.getId(),
+                team.getTeamName().name()
+        );
+    }
+}
+

--- a/src/main/java/com/jolupbisang/demo/application/team/query/dto/TeamMemberRes.java
+++ b/src/main/java/com/jolupbisang/demo/application/team/query/dto/TeamMemberRes.java
@@ -1,0 +1,29 @@
+package com.jolupbisang.demo.application.team.query.dto;
+
+import com.jolupbisang.demo.domain.user.User;
+
+import java.util.List;
+
+public record TeamMemberRes(
+        List<Member> members
+) {
+    public static TeamMemberRes from(List<User> users) {
+        List<Member> members = users.stream()
+                .map(user -> new Member(
+                        user.getId(),
+                        user.getNickname(),
+                        user.getPictureURL()
+                ))
+                .toList();
+
+        return new TeamMemberRes(members);
+    }
+
+    private record Member(
+            Long id,
+            String name,
+            String pictureURL
+    ) {
+    }
+}
+

--- a/src/main/java/com/jolupbisang/demo/domain/team/exception/TeamDomainErrorCode.java
+++ b/src/main/java/com/jolupbisang/demo/domain/team/exception/TeamDomainErrorCode.java
@@ -1,0 +1,16 @@
+package com.jolupbisang.demo.domain.team.exception;
+
+import com.jolupbisang.demo.global.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum TeamDomainErrorCode implements ErrorCode {
+    INVALID_TEAM_NAME("TD-0001", HttpStatus.BAD_REQUEST, "잘못된 팀 이름입니다.");
+
+    private final String code;
+    private final HttpStatus status;
+    private final String message;
+}

--- a/src/main/java/com/jolupbisang/demo/domain/team/exception/TeamDomainErrorCode.java
+++ b/src/main/java/com/jolupbisang/demo/domain/team/exception/TeamDomainErrorCode.java
@@ -8,7 +8,8 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum TeamDomainErrorCode implements ErrorCode {
-    INVALID_TEAM_NAME("TD-0001", HttpStatus.BAD_REQUEST, "잘못된 팀 이름입니다.");
+    INVALID_TEAM_NAME("TD-0001", HttpStatus.BAD_REQUEST, "잘못된 팀 이름입니다."),
+    NULL_TEAM_NAME("TD-0002", HttpStatus.BAD_REQUEST, "팀 이름은 필수 입니다.");
 
     private final String code;
     private final HttpStatus status;

--- a/src/main/java/com/jolupbisang/demo/domain/team/exception/TeamDomainErrorCode.java
+++ b/src/main/java/com/jolupbisang/demo/domain/team/exception/TeamDomainErrorCode.java
@@ -13,7 +13,8 @@ public enum TeamDomainErrorCode implements ErrorCode {
     NULL_TEAM("TD-0003", HttpStatus.BAD_REQUEST, "팀은 필수입니다."),
     INVALID_USER_ID("TD-0004", HttpStatus.BAD_REQUEST, "사용자 ID는 0보다 커야 합니다."),
     NULL_TEAM_MEMBER_ROLE("TD-0005", HttpStatus.BAD_REQUEST, "팀 멤버 역할은 필수입니다."),
-    EMPTY_TEAM_MEMBERS("TD-0006", HttpStatus.BAD_REQUEST, "팀 멤버는 최소 1명 이상이어야 합니다.");
+    EMPTY_TEAM_MEMBERS("TD-0006", HttpStatus.BAD_REQUEST, "팀 멤버는 최소 1명 이상이어야 합니다."),
+    NOT_MEMBER("TD-0007", HttpStatus.UNAUTHORIZED, "팀 멤버만 가능합니다.");
 
     private final String code;
     private final HttpStatus status;

--- a/src/main/java/com/jolupbisang/demo/domain/team/exception/TeamDomainErrorCode.java
+++ b/src/main/java/com/jolupbisang/demo/domain/team/exception/TeamDomainErrorCode.java
@@ -12,7 +12,8 @@ public enum TeamDomainErrorCode implements ErrorCode {
     NULL_TEAM_NAME("TD-0002", HttpStatus.BAD_REQUEST, "팀 이름은 필수 입니다."),
     NULL_TEAM("TD-0003", HttpStatus.BAD_REQUEST, "팀은 필수입니다."),
     INVALID_USER_ID("TD-0004", HttpStatus.BAD_REQUEST, "사용자 ID는 0보다 커야 합니다."),
-    NULL_TEAM_MEMBER_ROLE("TD-0005", HttpStatus.BAD_REQUEST, "팀 멤버 역할은 필수입니다.");
+    NULL_TEAM_MEMBER_ROLE("TD-0005", HttpStatus.BAD_REQUEST, "팀 멤버 역할은 필수입니다."),
+    EMPTY_TEAM_MEMBERS("TD-0006", HttpStatus.BAD_REQUEST, "팀 멤버는 최소 1명 이상이어야 합니다.");
 
     private final String code;
     private final HttpStatus status;

--- a/src/main/java/com/jolupbisang/demo/domain/team/exception/TeamDomainErrorCode.java
+++ b/src/main/java/com/jolupbisang/demo/domain/team/exception/TeamDomainErrorCode.java
@@ -9,7 +9,10 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum TeamDomainErrorCode implements ErrorCode {
     INVALID_TEAM_NAME("TD-0001", HttpStatus.BAD_REQUEST, "잘못된 팀 이름입니다."),
-    NULL_TEAM_NAME("TD-0002", HttpStatus.BAD_REQUEST, "팀 이름은 필수 입니다.");
+    NULL_TEAM_NAME("TD-0002", HttpStatus.BAD_REQUEST, "팀 이름은 필수 입니다."),
+    NULL_TEAM("TD-0003", HttpStatus.BAD_REQUEST, "팀은 필수입니다."),
+    INVALID_USER_ID("TD-0004", HttpStatus.BAD_REQUEST, "사용자 ID는 0보다 커야 합니다."),
+    NULL_TEAM_MEMBER_ROLE("TD-0005", HttpStatus.BAD_REQUEST, "팀 멤버 역할은 필수입니다.");
 
     private final String code;
     private final HttpStatus status;

--- a/src/main/java/com/jolupbisang/demo/domain/team/exception/TeamDomainErrorCode.java
+++ b/src/main/java/com/jolupbisang/demo/domain/team/exception/TeamDomainErrorCode.java
@@ -14,7 +14,8 @@ public enum TeamDomainErrorCode implements ErrorCode {
     INVALID_USER_ID("TD-0004", HttpStatus.BAD_REQUEST, "사용자 ID는 0보다 커야 합니다."),
     NULL_TEAM_MEMBER_ROLE("TD-0005", HttpStatus.BAD_REQUEST, "팀 멤버 역할은 필수입니다."),
     EMPTY_TEAM_MEMBERS("TD-0006", HttpStatus.BAD_REQUEST, "팀 멤버는 최소 1명 이상이어야 합니다."),
-    NOT_MEMBER("TD-0007", HttpStatus.UNAUTHORIZED, "팀 멤버만 가능합니다.");
+    NOT_MEMBER("TD-0007", HttpStatus.UNAUTHORIZED, "팀 멤버만 가능합니다."),
+    ONLY_FOR_OWNER_AUTHORITY("TD-0008", HttpStatus.UNAUTHORIZED, "팀 방장만 가능합니다.");
 
     private final String code;
     private final HttpStatus status;

--- a/src/main/java/com/jolupbisang/demo/domain/team/model/Team.java
+++ b/src/main/java/com/jolupbisang/demo/domain/team/model/Team.java
@@ -67,6 +67,8 @@ public class Team {
     }
 
     public void addMember(Long userId, TeamMemberRole role) {
+        if (isMember(userId)) return;
+        
         TeamMember member = new TeamMember(this, userId, role);
         this.members.add(member);
     }
@@ -79,6 +81,17 @@ public class Team {
     public void validateViewAuthority(Long accessUserId) {
         if (!isMember(accessUserId)) {
             throw new DomainException(TeamDomainErrorCode.NOT_MEMBER, "userId: %d", accessUserId);
+        }
+    }
+
+    public boolean isOwner(Long userId) {
+        return members.stream()
+                .anyMatch(member -> member.getUserId().equals(userId) && member.getRole() == TeamMemberRole.TEAM_OWNER);
+    }
+
+    public void validateOwnerAuthority(Long accessUserId) {
+        if (!isOwner(accessUserId)) {
+            throw new DomainException(TeamDomainErrorCode.ONLY_FOR_OWNER_AUTHORITY, "userId: %d", accessUserId);
         }
     }
 }

--- a/src/main/java/com/jolupbisang/demo/domain/team/model/Team.java
+++ b/src/main/java/com/jolupbisang/demo/domain/team/model/Team.java
@@ -1,0 +1,32 @@
+package com.jolupbisang.demo.domain.team.model;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Team {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Embedded
+    private TeamName teamName;
+
+    @OneToMany(mappedBy = "team", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    List<TeamMember> members = new ArrayList<>();
+}

--- a/src/main/java/com/jolupbisang/demo/domain/team/model/Team.java
+++ b/src/main/java/com/jolupbisang/demo/domain/team/model/Team.java
@@ -32,8 +32,9 @@ public class Team {
     @OneToMany(mappedBy = "team", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     List<TeamMember> members = new ArrayList<>();
 
-    public Team(TeamName teamName) {
+    public Team(TeamName teamName, Long creatorId, List<Long> memberIds) {
         setTeamName(teamName);
+        setMembers(creatorId, memberIds);
     }
 
     private void setTeamName(TeamName teamName) {
@@ -41,5 +42,32 @@ public class Team {
             throw new DomainException(TeamDomainErrorCode.NULL_TEAM_NAME);
         }
         this.teamName = teamName;
+    }
+
+    private void setMembers(Long creatorId, List<Long> memberIds) {
+        if (creatorId == null || creatorId <= 0) {
+            throw new DomainException(TeamDomainErrorCode.INVALID_USER_ID, "creatorId: %d", creatorId);
+        }
+        if (memberIds == null) {
+            throw new DomainException(TeamDomainErrorCode.EMPTY_TEAM_MEMBERS);
+        }
+
+        // 생성자는 TEAM_OWNER 역할로 추가
+        members.add(new TeamMember(this, creatorId, TeamMemberRole.TEAM_OWNER));
+
+        // 리스트에서 생성자 제외하고 중복 제거 후 TEAM_MEMBER로 추가
+        List<Long> distinctMemberIds = memberIds.stream()
+                .filter(memberId -> !memberId.equals(creatorId))
+                .distinct()
+                .toList();
+
+        distinctMemberIds.forEach(memberId ->
+                members.add(new TeamMember(this, memberId, TeamMemberRole.TEAM_MEMBER))
+        );
+    }
+
+    public void addMember(Long userId, TeamMemberRole role) {
+        TeamMember member = new TeamMember(this, userId, role);
+        this.members.add(member);
     }
 }

--- a/src/main/java/com/jolupbisang/demo/domain/team/model/Team.java
+++ b/src/main/java/com/jolupbisang/demo/domain/team/model/Team.java
@@ -1,5 +1,7 @@
 package com.jolupbisang.demo.domain.team.model;
 
+import com.jolupbisang.demo.domain.team.exception.TeamDomainErrorCode;
+import com.jolupbisang.demo.global.exception.DomainException;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
@@ -29,4 +31,15 @@ public class Team {
 
     @OneToMany(mappedBy = "team", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     List<TeamMember> members = new ArrayList<>();
+
+    public Team(TeamName teamName) {
+        setTeamName(teamName);
+    }
+
+    private void setTeamName(TeamName teamName) {
+        if (teamName == null) {
+            throw new DomainException(TeamDomainErrorCode.NULL_TEAM_NAME);
+        }
+        this.teamName = teamName;
+    }
 }

--- a/src/main/java/com/jolupbisang/demo/domain/team/model/Team.java
+++ b/src/main/java/com/jolupbisang/demo/domain/team/model/Team.java
@@ -70,4 +70,15 @@ public class Team {
         TeamMember member = new TeamMember(this, userId, role);
         this.members.add(member);
     }
+
+    public boolean isMember(Long userId) {
+        return members.stream()
+                .anyMatch(member -> member.getUserId().equals(userId));
+    }
+
+    public void validateViewAuthority(Long accessUserId) {
+        if (!isMember(accessUserId)) {
+            throw new DomainException(TeamDomainErrorCode.NOT_MEMBER, "userId: %d", accessUserId);
+        }
+    }
 }

--- a/src/main/java/com/jolupbisang/demo/domain/team/model/TeamMember.java
+++ b/src/main/java/com/jolupbisang/demo/domain/team/model/TeamMember.java
@@ -1,0 +1,27 @@
+package com.jolupbisang.demo.domain.team.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.Getter;
+
+@Getter
+@Entity
+public class TeamMember {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "team_id")
+    private Team team;
+
+    @Column(name = "user_id")
+    private Long userId;
+}

--- a/src/main/java/com/jolupbisang/demo/domain/team/model/TeamMember.java
+++ b/src/main/java/com/jolupbisang/demo/domain/team/model/TeamMember.java
@@ -1,17 +1,24 @@
 package com.jolupbisang.demo.domain.team.model;
 
+import com.jolupbisang.demo.domain.team.exception.TeamDomainErrorCode;
+import com.jolupbisang.demo.global.exception.DomainException;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class TeamMember {
 
     @Id
@@ -24,4 +31,35 @@ public class TeamMember {
 
     @Column(name = "user_id")
     private Long userId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "role")
+    private TeamMemberRole role;
+
+    public TeamMember(Team team, Long userId, TeamMemberRole role) {
+        setTeam(team);
+        setUserId(userId);
+        setRole(role);
+    }
+
+    private void setTeam(Team team) {
+        if (team == null) {
+            throw new DomainException(TeamDomainErrorCode.NULL_TEAM);
+        }
+        this.team = team;
+    }
+
+    private void setUserId(Long userId) {
+        if (userId == null || userId <= 0) {
+            throw new DomainException(TeamDomainErrorCode.INVALID_USER_ID, "userId: %d", userId);
+        }
+        this.userId = userId;
+    }
+
+    private void setRole(TeamMemberRole role) {
+        if (role == null) {
+            throw new DomainException(TeamDomainErrorCode.NULL_TEAM_MEMBER_ROLE);
+        }
+        this.role = role;
+    }
 }

--- a/src/main/java/com/jolupbisang/demo/domain/team/model/TeamMemberRole.java
+++ b/src/main/java/com/jolupbisang/demo/domain/team/model/TeamMemberRole.java
@@ -1,0 +1,5 @@
+package com.jolupbisang.demo.domain.team.model;
+
+public enum TeamMemberRole {
+    TEAM_OWNER, TEAM_MEMBER
+}

--- a/src/main/java/com/jolupbisang/demo/domain/team/model/TeamName.java
+++ b/src/main/java/com/jolupbisang/demo/domain/team/model/TeamName.java
@@ -2,16 +2,26 @@ package com.jolupbisang.demo.domain.team.model;
 
 import com.jolupbisang.demo.domain.team.exception.TeamDomainErrorCode;
 import com.jolupbisang.demo.global.exception.DomainException;
+import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Embeddable
-public record TeamName(
-        String name
-) {
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EqualsAndHashCode
+public class TeamName {
 
-    public TeamName {
+    @Column(name = "name")
+    private String name;
+
+    public TeamName(String name) {
         if (name == null || name.isBlank()) {
-            throw new DomainException(TeamDomainErrorCode.INVALID_TEAM_NAME, "name:%d", name);
+            throw new DomainException(TeamDomainErrorCode.INVALID_TEAM_NAME, "name:%s", name);
         }
+        this.name = name;
     }
 }

--- a/src/main/java/com/jolupbisang/demo/domain/team/model/TeamName.java
+++ b/src/main/java/com/jolupbisang/demo/domain/team/model/TeamName.java
@@ -1,0 +1,17 @@
+package com.jolupbisang.demo.domain.team.model;
+
+import com.jolupbisang.demo.domain.team.exception.TeamDomainErrorCode;
+import com.jolupbisang.demo.global.exception.DomainException;
+import jakarta.persistence.Embeddable;
+
+@Embeddable
+public record TeamName(
+        String name
+) {
+
+    public TeamName {
+        if (name == null || name.isBlank()) {
+            throw new DomainException(TeamDomainErrorCode.INVALID_TEAM_NAME, "name:%d", name);
+        }
+    }
+}

--- a/src/main/java/com/jolupbisang/demo/infrastructure/team/TeamRepository.java
+++ b/src/main/java/com/jolupbisang/demo/infrastructure/team/TeamRepository.java
@@ -5,7 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
-public interface TeamRepository extends JpaRepository<Team, Long> {
+public interface TeamRepository extends JpaRepository<Team, Long>, TeamRepositoryCustom {
     
     List<Team> findByMembersUserId(Long userId);
 }

--- a/src/main/java/com/jolupbisang/demo/infrastructure/team/TeamRepository.java
+++ b/src/main/java/com/jolupbisang/demo/infrastructure/team/TeamRepository.java
@@ -3,6 +3,9 @@ package com.jolupbisang.demo.infrastructure.team;
 import com.jolupbisang.demo.domain.team.model.Team;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface TeamRepository extends JpaRepository<Team, Long> {
     
+    List<Team> findByMembersUserId(Long userId);
 }

--- a/src/main/java/com/jolupbisang/demo/infrastructure/team/TeamRepository.java
+++ b/src/main/java/com/jolupbisang/demo/infrastructure/team/TeamRepository.java
@@ -1,0 +1,8 @@
+package com.jolupbisang.demo.infrastructure.team;
+
+import com.jolupbisang.demo.domain.team.model.Team;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TeamRepository extends JpaRepository<Team, Long> {
+    
+}

--- a/src/main/java/com/jolupbisang/demo/infrastructure/team/TeamRepositoryCustom.java
+++ b/src/main/java/com/jolupbisang/demo/infrastructure/team/TeamRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.jolupbisang.demo.infrastructure.team;
+
+import com.jolupbisang.demo.domain.team.model.Team;
+
+import java.util.Optional;
+
+public interface TeamRepositoryCustom {
+    Optional<Team> findByIdWithMembers(Long teamId);
+}
+

--- a/src/main/java/com/jolupbisang/demo/infrastructure/team/TeamRepositoryImpl.java
+++ b/src/main/java/com/jolupbisang/demo/infrastructure/team/TeamRepositoryImpl.java
@@ -1,0 +1,28 @@
+package com.jolupbisang.demo.infrastructure.team;
+
+import com.jolupbisang.demo.domain.team.model.Team;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Optional;
+
+import static com.jolupbisang.demo.domain.team.model.QTeam.team;
+import static com.jolupbisang.demo.domain.team.model.QTeamMember.teamMember;
+
+@RequiredArgsConstructor
+public class TeamRepositoryImpl implements TeamRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Optional<Team> findByIdWithMembers(Long teamId) {
+        Team resultTeam = queryFactory
+                .selectFrom(team)
+                .leftJoin(team.members, teamMember).fetchJoin()
+                .where(team.id.eq(teamId))
+                .fetchOne();
+
+        return Optional.ofNullable(resultTeam);
+    }
+}
+

--- a/src/main/java/com/jolupbisang/demo/infrastructure/whisper/WhisperClient.java
+++ b/src/main/java/com/jolupbisang/demo/infrastructure/whisper/WhisperClient.java
@@ -1,11 +1,15 @@
 package com.jolupbisang.demo.infrastructure.whisper;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.jolupbisang.demo.application.event.whisper.WhisperContextEvent;
+import com.jolupbisang.demo.application.context.event.WhisperContextEvent;
 import com.jolupbisang.demo.application.event.whisper.WhisperEmbeddedEvent;
 import com.jolupbisang.demo.application.segment.event.TextTranslatedEvent;
 import com.jolupbisang.demo.global.properties.WhisperProperties;
-import com.jolupbisang.demo.infrastructure.audio.client.dto.request.*;
+import com.jolupbisang.demo.infrastructure.audio.client.dto.request.ContextDoneRequest;
+import com.jolupbisang.demo.infrastructure.audio.client.dto.request.ContextRequest;
+import com.jolupbisang.demo.infrastructure.audio.client.dto.request.DiarizedRequest;
+import com.jolupbisang.demo.infrastructure.audio.client.dto.request.EmbeddingRequest;
+import com.jolupbisang.demo.infrastructure.audio.client.dto.request.ReferenceRequest;
 import com.jolupbisang.demo.infrastructure.audio.client.dto.response.ContextResponse;
 import com.jolupbisang.demo.infrastructure.audio.client.dto.response.EmbeddedVectorResponse;
 import com.jolupbisang.demo.infrastructure.audio.client.dto.response.WhisperResponseType;
@@ -40,8 +44,8 @@ public class WhisperClient extends BinaryWebSocketHandler {
 
     private final WhisperProperties whisperProperties;
 
-    private static final int MAX_RETRY_ATTEMPTS = 5;
-    private static final int RETRY_DELAY_SECONDS = 5;
+    private static final int MAX_RETRY_ATTEMPTS = 1;
+    private static final int RETRY_DELAY_SECONDS = 1;
 
     @PostConstruct
     public void init() {

--- a/src/main/java/com/jolupbisang/demo/presentation/team/TeamCreationController.java
+++ b/src/main/java/com/jolupbisang/demo/presentation/team/TeamCreationController.java
@@ -1,0 +1,29 @@
+package com.jolupbisang.demo.presentation.team;
+
+import com.jolupbisang.demo.application.team.TeamCreationService;
+import com.jolupbisang.demo.application.team.command.dto.TeamCreationReq;
+import com.jolupbisang.demo.application.team.command.dto.TeamCreationRes;
+import com.jolupbisang.demo.infrastructure.auth.security.CustomUserDetails;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class TeamCreationController {
+
+    private final TeamCreationService teamCreationService;
+
+    @PostMapping("/api/v1/teams")
+    public ResponseEntity<TeamCreationRes> createTeam(@RequestBody @Valid TeamCreationReq teamCreationReq,
+                                                      @AuthenticationPrincipal CustomUserDetails userDetails) {
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(teamCreationService.create(teamCreationReq, userDetails.getUserId()));
+    }
+}

--- a/src/main/java/com/jolupbisang/demo/presentation/team/TeamDetailQueryController.java
+++ b/src/main/java/com/jolupbisang/demo/presentation/team/TeamDetailQueryController.java
@@ -1,0 +1,29 @@
+package com.jolupbisang.demo.presentation.team;
+
+import com.jolupbisang.demo.application.team.query.TeamDetailQueryService;
+import com.jolupbisang.demo.application.team.query.dto.TeamDetailRes;
+import com.jolupbisang.demo.infrastructure.auth.security.CustomUserDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class TeamDetailQueryController {
+
+    private final TeamDetailQueryService teamDetailQueryService;
+
+    @GetMapping("/api/v1/teams/{teamId}")
+    public ResponseEntity<TeamDetailRes> getTeamDetail(
+            @PathVariable Long teamId,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        
+        TeamDetailRes teamDetail = teamDetailQueryService.getTeamDetail(teamId, userDetails.getUserId());
+        
+        return ResponseEntity.ok(teamDetail);
+    }
+}
+

--- a/src/main/java/com/jolupbisang/demo/presentation/team/TeamListQueryController.java
+++ b/src/main/java/com/jolupbisang/demo/presentation/team/TeamListQueryController.java
@@ -1,0 +1,27 @@
+package com.jolupbisang.demo.presentation.team;
+
+import com.jolupbisang.demo.application.team.query.TeamListQueryService;
+import com.jolupbisang.demo.application.team.query.dto.TeamListRes;
+import com.jolupbisang.demo.infrastructure.auth.security.CustomUserDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class TeamListQueryController {
+
+    private final TeamListQueryService teamListQueryService;
+
+    @GetMapping("/api/v1/teams")
+    public ResponseEntity<List<TeamListRes>> getMyTeams(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        List<TeamListRes> teams = teamListQueryService.getTeamsByUserId(userDetails.getUserId());
+        
+        return ResponseEntity.ok(teams);
+    }
+}
+

--- a/src/main/java/com/jolupbisang/demo/presentation/team/TeamMemberAdditionController.java
+++ b/src/main/java/com/jolupbisang/demo/presentation/team/TeamMemberAdditionController.java
@@ -1,0 +1,34 @@
+package com.jolupbisang.demo.presentation.team;
+
+import com.jolupbisang.demo.application.team.command.TeamMemberAdditionService;
+import com.jolupbisang.demo.application.team.command.dto.TeamMemberAdditionReq;
+import com.jolupbisang.demo.application.team.command.dto.TeamMemberAdditionRes;
+import com.jolupbisang.demo.infrastructure.auth.security.CustomUserDetails;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class TeamMemberAdditionController {
+
+    private final TeamMemberAdditionService teamMemberAdditionService;
+
+    @PostMapping("/api/v1/teams/{teamId}/members")
+    public ResponseEntity<TeamMemberAdditionRes> addMember(
+            @PathVariable Long teamId,
+            @RequestBody @Valid TeamMemberAdditionReq request,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(teamMemberAdditionService.addMember(teamId, userDetails.getUserId(), request));
+    }
+}
+

--- a/src/main/java/com/jolupbisang/demo/presentation/team/TeamMemberQueryController.java
+++ b/src/main/java/com/jolupbisang/demo/presentation/team/TeamMemberQueryController.java
@@ -1,0 +1,29 @@
+package com.jolupbisang.demo.presentation.team;
+
+import com.jolupbisang.demo.application.team.query.TeamMemberQueryService;
+import com.jolupbisang.demo.application.team.query.dto.TeamMemberRes;
+import com.jolupbisang.demo.infrastructure.auth.security.CustomUserDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class TeamMemberQueryController {
+
+    private final TeamMemberQueryService teamMemberQueryService;
+
+    @GetMapping("/api/v1/teams/{teamId}/members")
+    public ResponseEntity<TeamMemberRes> getTeamMembers(
+            @PathVariable Long teamId,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+
+        TeamMemberRes members = teamMemberQueryService.getTeamMembers(teamId, userDetails.getUserId());
+
+        return ResponseEntity.ok(members);
+    }
+}
+


### PR DESCRIPTION
## 구현 기능
- 팀 생성
- 속한 팀 목록 조회
- 팀 정보 조회
- 팀 구성원 추가
- 팀 구성원 조회

## 이슈
Java Record로 값객체 선언시 QClass를 생성하지 못하는 문제가 있음 -> 모두 일반 클래스로 대체

-> QueryDSL 메인테이너가 방치중