### PR TITLE
feat: 회의록 폴더 기능 추가

### DIFF
--- a/src/main/java/com/jolupbisang/demo/application/meetingFolder/command/MeetingFolderCreationService.java
+++ b/src/main/java/com/jolupbisang/demo/application/meetingFolder/command/MeetingFolderCreationService.java
@@ -1,0 +1,26 @@
+package com.jolupbisang.demo.application.meetingFolder.command;
+
+import com.jolupbisang.demo.application.meetingFolder.command.dto.MeetingFolderCreationReq;
+import com.jolupbisang.demo.application.meetingFolder.command.dto.MeetingFolderCreationRes;
+import com.jolupbisang.demo.domain.meetingFolder.model.MeetingFolder;
+import com.jolupbisang.demo.infrastructure.meetingFolder.MeetingFolderRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MeetingFolderCreationService {
+
+    private final MeetingFolderRepository meetingFolderRepository;
+
+    @Transactional
+    public MeetingFolderCreationRes create(Long userId, MeetingFolderCreationReq req) {
+        MeetingFolder meetingFolder = new MeetingFolder(userId, req.name(), null);
+        meetingFolderRepository.save(meetingFolder);
+
+        return MeetingFolderCreationRes.of(meetingFolder.getId());
+    }
+}
+
+

--- a/src/main/java/com/jolupbisang/demo/application/meetingFolder/command/MeetingFolderDeletionService.java
+++ b/src/main/java/com/jolupbisang/demo/application/meetingFolder/command/MeetingFolderDeletionService.java
@@ -1,0 +1,34 @@
+package com.jolupbisang.demo.application.meetingFolder.command;
+
+import com.jolupbisang.demo.application.meetingFolder.command.dto.MeetingFolderDeletionReq;
+import com.jolupbisang.demo.application.meetingFolder.command.dto.MeetingFolderDeletionRes;
+import com.jolupbisang.demo.domain.meetingFolder.model.MeetingFolder;
+import com.jolupbisang.demo.infrastructure.meetingFolder.MeetingFolderRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class MeetingFolderDeletionService {
+
+    private final MeetingFolderRepository meetingFolderRepository;
+
+    @Transactional
+    public MeetingFolderDeletionRes delete(Long userId, MeetingFolderDeletionReq req) {
+        List<MeetingFolder> folders = meetingFolderRepository.findAllById(req.folderIds());
+
+        List<Long> successFolderIds = new ArrayList<>();
+        for (MeetingFolder folder : folders) {
+            folder.validateOwnerAuthority(userId);
+            meetingFolderRepository.delete(folder);
+            successFolderIds.add(folder.getId());
+        }
+
+        return MeetingFolderDeletionRes.of(successFolderIds);
+    }
+}
+

--- a/src/main/java/com/jolupbisang/demo/application/meetingFolder/command/MeetingFolderUpdateService.java
+++ b/src/main/java/com/jolupbisang/demo/application/meetingFolder/command/MeetingFolderUpdateService.java
@@ -1,0 +1,72 @@
+package com.jolupbisang.demo.application.meetingFolder.command;
+
+import com.jolupbisang.demo.application.meetingFolder.command.dto.MeetingFolderUpdateReq;
+import com.jolupbisang.demo.application.meetingFolder.command.dto.MeetingFolderUpdateRes;
+import com.jolupbisang.demo.application.meetingFolder.exception.MeetingFolderApplicationErrorCode;
+import com.jolupbisang.demo.domain.meeting.model.Meeting;
+import com.jolupbisang.demo.domain.meetingFolder.model.MeetingFolder;
+import com.jolupbisang.demo.global.exception.ApplicationException;
+import com.jolupbisang.demo.infrastructure.meeting.MeetingRepository;
+import com.jolupbisang.demo.infrastructure.meetingFolder.MeetingFolderRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class MeetingFolderUpdateService {
+
+    private final MeetingFolderRepository meetingFolderRepository;
+    private final MeetingRepository meetingRepository;
+
+    @Transactional
+    public MeetingFolderUpdateRes addMeetings(Long userId, Long folderId, MeetingFolderUpdateReq req) {
+        MeetingFolder folder = meetingFolderRepository.findById(folderId)
+                .orElseThrow(() -> new ApplicationException(MeetingFolderApplicationErrorCode.NOT_FOUND_FOLDER, "folderId: %d", folderId));
+
+        folder.validateOwnerAuthority(userId);
+
+        List<Meeting> meetings = meetingRepository.findByIdsWithParticipant(req.meetingIds());
+
+        if (meetings.size() != req.meetingIds().size()) {
+            throw new ApplicationException(MeetingFolderApplicationErrorCode.NOT_FOUND_MEETING);
+        }
+
+        List<Long> successMeetingIds = new ArrayList<>();
+        for (Meeting meeting : meetings) {
+            if (!meeting.isParticipant(userId)) {
+                throw new ApplicationException(MeetingFolderApplicationErrorCode.NOT_MEETING_PARTICIPANT, "meetingId: %d, userId: %d", meeting.getId(), userId);
+            }
+
+            if (!folder.hasMeeting(meeting.getId())) {
+                folder.addMeeting(meeting.getId());
+                successMeetingIds.add(meeting.getId());
+            }
+        }
+
+        return MeetingFolderUpdateRes.of(successMeetingIds);
+    }
+
+    @Transactional
+    public MeetingFolderUpdateRes removeMeetings(Long userId, Long folderId, MeetingFolderUpdateReq req) {
+        MeetingFolder folder = meetingFolderRepository.findByIdWithMeetings(folderId)
+                .orElseThrow(() -> new ApplicationException(MeetingFolderApplicationErrorCode.NOT_FOUND_FOLDER, "folderId: %d", folderId));
+
+        folder.validateOwnerAuthority(userId);
+
+        List<Long> successMeetingIds = new ArrayList<>();
+        for (Long meetingId : req.meetingIds()) {
+            if (folder.hasMeeting(meetingId)) {
+                folder.removeMeeting(meetingId);
+                successMeetingIds.add(meetingId);
+            }
+        }
+
+        return MeetingFolderUpdateRes.of(successMeetingIds);
+    }
+}
+
+

--- a/src/main/java/com/jolupbisang/demo/application/meetingFolder/command/dto/MeetingFolderCreationReq.java
+++ b/src/main/java/com/jolupbisang/demo/application/meetingFolder/command/dto/MeetingFolderCreationReq.java
@@ -1,0 +1,11 @@
+package com.jolupbisang.demo.application.meetingFolder.command.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record MeetingFolderCreationReq(
+        @NotBlank(message = "폴더 이름은 필수입니다.")
+        String name
+) {
+}
+
+

--- a/src/main/java/com/jolupbisang/demo/application/meetingFolder/command/dto/MeetingFolderCreationRes.java
+++ b/src/main/java/com/jolupbisang/demo/application/meetingFolder/command/dto/MeetingFolderCreationRes.java
@@ -1,0 +1,11 @@
+package com.jolupbisang.demo.application.meetingFolder.command.dto;
+
+public record MeetingFolderCreationRes(
+        Long folderId
+) {
+    public static MeetingFolderCreationRes of(Long folderId) {
+        return new MeetingFolderCreationRes(folderId);
+    }
+}
+
+

--- a/src/main/java/com/jolupbisang/demo/application/meetingFolder/command/dto/MeetingFolderDeletionReq.java
+++ b/src/main/java/com/jolupbisang/demo/application/meetingFolder/command/dto/MeetingFolderDeletionReq.java
@@ -1,0 +1,14 @@
+package com.jolupbisang.demo.application.meetingFolder.command.dto;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.List;
+
+public record MeetingFolderDeletionReq(
+        @NotEmpty(message = "폴더 ID 목록은 필수입니다.")
+        @NotNull(message = "폴더 ID 목록은 필수입니다.")
+        List<Long> folderIds
+) {
+}
+

--- a/src/main/java/com/jolupbisang/demo/application/meetingFolder/command/dto/MeetingFolderDeletionRes.java
+++ b/src/main/java/com/jolupbisang/demo/application/meetingFolder/command/dto/MeetingFolderDeletionRes.java
@@ -1,0 +1,12 @@
+package com.jolupbisang.demo.application.meetingFolder.command.dto;
+
+import java.util.List;
+
+public record MeetingFolderDeletionRes(
+        List<Long> successFolderIds
+) {
+    public static MeetingFolderDeletionRes of(List<Long> successFolderIds) {
+        return new MeetingFolderDeletionRes(successFolderIds);
+    }
+}
+

--- a/src/main/java/com/jolupbisang/demo/application/meetingFolder/command/dto/MeetingFolderUpdateReq.java
+++ b/src/main/java/com/jolupbisang/demo/application/meetingFolder/command/dto/MeetingFolderUpdateReq.java
@@ -1,0 +1,13 @@
+package com.jolupbisang.demo.application.meetingFolder.command.dto;
+
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.List;
+
+public record MeetingFolderUpdateReq(
+        @NotEmpty(message = "회의 ID 목록은 필수입니다.")
+        @NotNull(message = "회의 ID 목록은 필수입니다.")
+        List<Long> meetingIds
+) {
+}

--- a/src/main/java/com/jolupbisang/demo/application/meetingFolder/command/dto/MeetingFolderUpdateRes.java
+++ b/src/main/java/com/jolupbisang/demo/application/meetingFolder/command/dto/MeetingFolderUpdateRes.java
@@ -1,0 +1,12 @@
+package com.jolupbisang.demo.application.meetingFolder.command.dto;
+
+import java.util.List;
+
+public record MeetingFolderUpdateRes(
+        List<Long> successMeetingIds
+) {
+    public static MeetingFolderUpdateRes of(List<Long> successMeetingIds) {
+        return new MeetingFolderUpdateRes(successMeetingIds);
+    }
+}
+

--- a/src/main/java/com/jolupbisang/demo/application/meetingFolder/exception/MeetingFolderApplicationErrorCode.java
+++ b/src/main/java/com/jolupbisang/demo/application/meetingFolder/exception/MeetingFolderApplicationErrorCode.java
@@ -1,0 +1,20 @@
+package com.jolupbisang.demo.application.meetingFolder.exception;
+
+import com.jolupbisang.demo.global.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum MeetingFolderApplicationErrorCode implements ErrorCode {
+    NOT_FOUND_FOLDER("MFA-0001", HttpStatus.NOT_FOUND, "존재하지 않는 폴더입니다."),
+    NOT_FOUND_MEETING("MFA-0002", HttpStatus.NOT_FOUND, "존재하지 않는 회의입니다."),
+    NOT_FOLDER_OWNER("MFA-0003", HttpStatus.FORBIDDEN, "폴더 소유자만 접근할 수 있습니다."),
+    NOT_MEETING_PARTICIPANT("MFA-0004", HttpStatus.FORBIDDEN, "회의 참여자만 폴더에 추가할 수 있습니다.");
+
+    private final String code;
+    private final HttpStatus status;
+    private final String message;
+}
+

--- a/src/main/java/com/jolupbisang/demo/application/meetingFolder/query/MeetingFolderDetailQueryService.java
+++ b/src/main/java/com/jolupbisang/demo/application/meetingFolder/query/MeetingFolderDetailQueryService.java
@@ -1,0 +1,44 @@
+package com.jolupbisang.demo.application.meetingFolder.query;
+
+import com.jolupbisang.demo.application.meetingFolder.exception.MeetingFolderApplicationErrorCode;
+import com.jolupbisang.demo.application.meetingFolder.query.dto.MeetingFolderDetailRes;
+import com.jolupbisang.demo.domain.meeting.model.Meeting;
+import com.jolupbisang.demo.domain.meetingFolder.model.MeetingFolder;
+import com.jolupbisang.demo.global.exception.ApplicationException;
+import com.jolupbisang.demo.infrastructure.meeting.MeetingRepository;
+import com.jolupbisang.demo.infrastructure.meetingFolder.MeetingFolderRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class MeetingFolderDetailQueryService {
+
+    private final MeetingFolderRepository meetingFolderRepository;
+    private final MeetingRepository meetingRepository;
+
+    @Transactional(readOnly = true)
+    public MeetingFolderDetailRes getFolderMeetings(Long userId, Long folderId) {
+        MeetingFolder folder = meetingFolderRepository.findByIdWithMeetings(folderId)
+                .orElseThrow(() -> new ApplicationException(MeetingFolderApplicationErrorCode.NOT_FOUND_FOLDER, "folderId: %d", folderId));
+
+        folder.validateOwnerAuthority(userId);
+
+        List<Long> meetingIds = folder.getMeetingIds();
+        if (meetingIds.isEmpty()) {
+            return MeetingFolderDetailRes.from(List.of());
+        }
+
+        List<Meeting> meetings = meetingRepository.findAllById(meetingIds);
+
+        List<MeetingFolderDetailRes.MeetingInfo> meetingInfos = meetings.stream()
+                .map(MeetingFolderDetailRes.MeetingInfo::fromEntity)
+                .toList();
+
+        return MeetingFolderDetailRes.from(meetingInfos);
+    }
+}
+

--- a/src/main/java/com/jolupbisang/demo/application/meetingFolder/query/MeetingFolderListQueryService.java
+++ b/src/main/java/com/jolupbisang/demo/application/meetingFolder/query/MeetingFolderListQueryService.java
@@ -1,0 +1,37 @@
+package com.jolupbisang.demo.application.meetingFolder.query;
+
+import com.jolupbisang.demo.application.meetingFolder.query.dto.MeetingFolderListRes;
+import com.jolupbisang.demo.domain.meeting.model.Meeting;
+import com.jolupbisang.demo.domain.meetingFolder.model.MeetingFolder;
+import com.jolupbisang.demo.infrastructure.meetingFolder.MeetingFolderRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class MeetingFolderListQueryService {
+
+    private final MeetingFolderRepository meetingFolderRepository;
+
+    @Transactional(readOnly = true)
+    public MeetingFolderListRes getFoldersByUserId(Long userId) {
+        List<MeetingFolder> folders = meetingFolderRepository.findByUserId(userId);
+        LocalDateTime now = LocalDateTime.now();
+
+        List<MeetingFolderListRes.MeetingFolderInfo> folderInfos = folders.stream()
+                .map(folder -> {
+                    Meeting closestMeeting = meetingFolderRepository.findClosestMeetingByMeetingIds(folder.getMeetingIds(), now)
+                            .orElse(null);
+                    return MeetingFolderListRes.MeetingFolderInfo.fromEntity(folder, closestMeeting);
+                })
+                .toList();
+
+        return MeetingFolderListRes.from(folderInfos);
+    }
+}
+
+

--- a/src/main/java/com/jolupbisang/demo/application/meetingFolder/query/dto/MeetingFolderDetailRes.java
+++ b/src/main/java/com/jolupbisang/demo/application/meetingFolder/query/dto/MeetingFolderDetailRes.java
@@ -1,0 +1,29 @@
+package com.jolupbisang.demo.application.meetingFolder.query.dto;
+
+import com.jolupbisang.demo.domain.meeting.model.Meeting;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record MeetingFolderDetailRes(
+        List<MeetingInfo> meetings
+) {
+    public static MeetingFolderDetailRes from(List<MeetingInfo> meetingInfos) {
+        return new MeetingFolderDetailRes(meetingInfos);
+    }
+
+    public record MeetingInfo(
+            Long meetingId,
+            String title,
+            LocalDateTime scheduledStartTime
+    ) {
+        public static MeetingInfo fromEntity(Meeting meeting) {
+            return new MeetingInfo(
+                    meeting.getId(),
+                    meeting.getTitle(),
+                    meeting.getScheduledTime().getScheduledStartTime()
+            );
+        }
+    }
+}
+

--- a/src/main/java/com/jolupbisang/demo/application/meetingFolder/query/dto/MeetingFolderListRes.java
+++ b/src/main/java/com/jolupbisang/demo/application/meetingFolder/query/dto/MeetingFolderListRes.java
@@ -1,0 +1,44 @@
+package com.jolupbisang.demo.application.meetingFolder.query.dto;
+
+import com.jolupbisang.demo.domain.meeting.model.Meeting;
+import com.jolupbisang.demo.domain.meetingFolder.model.MeetingFolder;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record MeetingFolderListRes(
+        List<MeetingFolderInfo> folders
+) {
+    public static MeetingFolderListRes from(List<MeetingFolderInfo> folderInfos) {
+        return new MeetingFolderListRes(folderInfos);
+    }
+
+    public record MeetingFolderInfo(
+            Long folderId,
+            String folderName,
+            String meetingName,
+            LocalDateTime scheduledStartTime,
+            LocalDateTime scheduledEndTime
+    ) {
+        public static MeetingFolderInfo fromEntity(MeetingFolder folder, Meeting closestMeeting) {
+            if (closestMeeting != null) {
+                return new MeetingFolderInfo(
+                        folder.getId(),
+                        folder.getName(),
+                        closestMeeting.getTitle(),
+                        closestMeeting.getScheduledTime().getScheduledStartTime(),
+                        closestMeeting.getScheduledTime().getScheduledEndTime()
+                );
+            }
+            return new MeetingFolderInfo(
+                    folder.getId(),
+                    folder.getName(),
+                    null,
+                    null,
+                    null
+            );
+        }
+    }
+}
+
+

--- a/src/main/java/com/jolupbisang/demo/domain/meetingFolder/exception/MeetingFolderDomainErrorCode.java
+++ b/src/main/java/com/jolupbisang/demo/domain/meetingFolder/exception/MeetingFolderDomainErrorCode.java
@@ -1,0 +1,23 @@
+package com.jolupbisang.demo.domain.meetingFolder.exception;
+
+import com.jolupbisang.demo.global.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum MeetingFolderDomainErrorCode implements ErrorCode {
+    EMPTY_FOLDER_NAME("MFD-0001", HttpStatus.BAD_REQUEST, "폴더 이름은 필수입니다."),
+    MEETING_ALREADY_IN_FOLDER("MFD-0002", HttpStatus.BAD_REQUEST, "이미 폴더에 포함된 회의입니다."),
+    MEETING_NOT_IN_FOLDER("MFD-0003", HttpStatus.BAD_REQUEST, "폴더에 포함되지 않은 회의입니다."),
+    INVALID_USER_ID("MFD-0004", HttpStatus.BAD_REQUEST, "사용자 ID는 0보다 커야합니다."),
+    NON_EXISTING_MEETING("MFD-0005", HttpStatus.BAD_REQUEST, "존재하지 않는 회의입니다."),
+    NOT_FOLDER_OWNER("MFD-0006", HttpStatus.FORBIDDEN, "폴더 소유자만 접근할 수 있습니다.");
+
+    private final String code;
+    private final HttpStatus status;
+    private final String message;
+}
+
+

--- a/src/main/java/com/jolupbisang/demo/domain/meetingFolder/model/MeetingFolder.java
+++ b/src/main/java/com/jolupbisang/demo/domain/meetingFolder/model/MeetingFolder.java
@@ -1,0 +1,96 @@
+package com.jolupbisang.demo.domain.meetingFolder.model;
+
+import com.jolupbisang.demo.domain.common.BaseTimeEntity;
+import com.jolupbisang.demo.domain.meetingFolder.exception.MeetingFolderDomainErrorCode;
+import com.jolupbisang.demo.global.exception.DomainException;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 회의록 폴더 관리 어그리거트 루트
+ */
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MeetingFolder extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(nullable = false)
+    private String name;
+
+    @OneToMany(mappedBy = "meetingFolder", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    private final List<MeetingFolderMeeting> meetings = new ArrayList<>();
+
+    public MeetingFolder(Long userId, String name, List<Long> meetingIds) {
+        setUserId(userId);
+        setName(name);
+        if (meetingIds != null && !meetingIds.isEmpty()) {
+            meetingIds.forEach(meetingId -> meetings.add(new MeetingFolderMeeting(this, meetingId)));
+        }
+    }
+
+    public void addMeeting(Long meetingId) {
+        if (meetingId == null) {
+            throw new DomainException(MeetingFolderDomainErrorCode.NON_EXISTING_MEETING, "meetingId: null");
+        }
+        if (hasMeeting(meetingId)) {
+            return;
+        }
+        meetings.add(new MeetingFolderMeeting(this, meetingId));
+    }
+
+    public void removeMeeting(Long meetingId) {
+        if (meetingId == null) {
+            throw new DomainException(MeetingFolderDomainErrorCode.NON_EXISTING_MEETING, "meetingId: null");
+        }
+        meetings.removeIf(m -> m.getMeetingId().equals(meetingId));
+    }
+
+    public boolean hasMeeting(Long meetingId) {
+        return meetings.stream()
+                .anyMatch(m -> m.getMeetingId().equals(meetingId));
+    }
+
+    public List<Long> getMeetingIds() {
+        return meetings.stream()
+                .map(MeetingFolderMeeting::getMeetingId)
+                .toList();
+    }
+
+    public void updateName(String name) {
+        setName(name);
+    }
+
+    public void validateOwnerAuthority(Long userId) {
+        if (!this.userId.equals(userId)) {
+            throw new DomainException(MeetingFolderDomainErrorCode.NOT_FOLDER_OWNER, "userId: %d", userId);
+        }
+    }
+
+    private void setUserId(Long userId) {
+        if (userId == null || userId <= 0) {
+            throw new DomainException(MeetingFolderDomainErrorCode.INVALID_USER_ID, "userId: %d", userId);
+        }
+        this.userId = userId;
+    }
+
+    private void setName(String name) {
+        if (name == null || name.isBlank()) {
+            throw new DomainException(MeetingFolderDomainErrorCode.EMPTY_FOLDER_NAME);
+        }
+        this.name = name;
+    }
+}
+
+

--- a/src/main/java/com/jolupbisang/demo/domain/meetingFolder/model/MeetingFolderMeeting.java
+++ b/src/main/java/com/jolupbisang/demo/domain/meetingFolder/model/MeetingFolderMeeting.java
@@ -1,0 +1,46 @@
+package com.jolupbisang.demo.domain.meetingFolder.model;
+
+import com.jolupbisang.demo.domain.meetingFolder.exception.MeetingFolderDomainErrorCode;
+import com.jolupbisang.demo.global.exception.DomainException;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "meeting_folder_meeting")
+public class MeetingFolderMeeting {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "meeting_folder_id", nullable = false)
+    private MeetingFolder meetingFolder;
+
+    @Column(name = "meeting_id", nullable = false)
+    private Long meetingId;
+
+    public MeetingFolderMeeting(MeetingFolder meetingFolder, Long meetingId) {
+        setMeetingFolder(meetingFolder);
+        setMeetingId(meetingId);
+    }
+
+    private void setMeetingFolder(MeetingFolder meetingFolder) {
+        if (meetingFolder == null) {
+            throw new DomainException(MeetingFolderDomainErrorCode.NON_EXISTING_MEETING, "meetingFolder: null");
+        }
+        this.meetingFolder = meetingFolder;
+    }
+
+    private void setMeetingId(Long meetingId) {
+        if (meetingId == null || meetingId <= 0) {
+            throw new DomainException(MeetingFolderDomainErrorCode.NON_EXISTING_MEETING, "meetingId: %d", meetingId);
+        }
+        this.meetingId = meetingId;
+    }
+}
+

--- a/src/main/java/com/jolupbisang/demo/infrastructure/meeting/MeetingRepositoryCustom.java
+++ b/src/main/java/com/jolupbisang/demo/infrastructure/meeting/MeetingRepositoryCustom.java
@@ -22,4 +22,6 @@ public interface MeetingRepositoryCustom {
     List<Meeting> findByScheduledTimeAndParticipantAndStatuses(LocalDateTime startTime, LocalDateTime endTime, long userId, Set<MeetingStatus> statuses);
 
     Optional<Meeting> findClosestMeetingByTeamId(Long teamId, LocalDateTime now);
+
+    List<Meeting> findByIdsWithParticipant(List<Long> meetingIds);
 }

--- a/src/main/java/com/jolupbisang/demo/infrastructure/meeting/MeetingRepositoryImpl.java
+++ b/src/main/java/com/jolupbisang/demo/infrastructure/meeting/MeetingRepositoryImpl.java
@@ -142,5 +142,17 @@ public class MeetingRepositoryImpl implements MeetingRepositoryCustom {
 
         return Optional.ofNullable(pastMeeting);
     }
+
+    @Override
+    public List<Meeting> findByIdsWithParticipant(List<Long> meetingIds) {
+        if (meetingIds == null || meetingIds.isEmpty()) {
+            return List.of();
+        }
+        return queryFactory
+                .selectFrom(meeting)
+                .leftJoin(meeting.participants, participant).fetchJoin()
+                .where(meeting.id.in(meetingIds))
+                .fetch();
+    }
 }
 

--- a/src/main/java/com/jolupbisang/demo/infrastructure/meetingFolder/MeetingFolderRepository.java
+++ b/src/main/java/com/jolupbisang/demo/infrastructure/meetingFolder/MeetingFolderRepository.java
@@ -1,0 +1,12 @@
+package com.jolupbisang.demo.infrastructure.meetingFolder;
+
+import com.jolupbisang.demo.domain.meetingFolder.model.MeetingFolder;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface MeetingFolderRepository extends JpaRepository<MeetingFolder, Long>, MeetingFolderRepositoryCustom {
+    List<MeetingFolder> findByUserId(Long userId);
+}
+
+

--- a/src/main/java/com/jolupbisang/demo/infrastructure/meetingFolder/MeetingFolderRepositoryCustom.java
+++ b/src/main/java/com/jolupbisang/demo/infrastructure/meetingFolder/MeetingFolderRepositoryCustom.java
@@ -1,0 +1,14 @@
+package com.jolupbisang.demo.infrastructure.meetingFolder;
+
+import com.jolupbisang.demo.domain.meeting.model.Meeting;
+import com.jolupbisang.demo.domain.meetingFolder.model.MeetingFolder;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+public interface MeetingFolderRepositoryCustom {
+    Optional<Meeting> findClosestMeetingByMeetingIds(java.util.List<Long> meetingIds, LocalDateTime now);
+    Optional<MeetingFolder> findByIdWithMeetings(Long folderId);
+}
+
+

--- a/src/main/java/com/jolupbisang/demo/infrastructure/meetingFolder/MeetingFolderRepositoryImpl.java
+++ b/src/main/java/com/jolupbisang/demo/infrastructure/meetingFolder/MeetingFolderRepositoryImpl.java
@@ -1,0 +1,64 @@
+package com.jolupbisang.demo.infrastructure.meetingFolder;
+
+import com.jolupbisang.demo.domain.meeting.model.Meeting;
+import com.jolupbisang.demo.domain.meetingFolder.model.MeetingFolder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static com.jolupbisang.demo.domain.meeting.model.QMeeting.meeting;
+import static com.jolupbisang.demo.domain.meetingFolder.model.QMeetingFolder.meetingFolder;
+import static com.jolupbisang.demo.domain.meetingFolder.model.QMeetingFolderMeeting.meetingFolderMeeting;
+
+@RequiredArgsConstructor
+public class MeetingFolderRepositoryImpl implements MeetingFolderRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Optional<Meeting> findClosestMeetingByMeetingIds(List<Long> meetingIds, LocalDateTime now) {
+        if (meetingIds == null || meetingIds.isEmpty()) {
+            return Optional.empty();
+        }
+
+        // 1. 미래 회의 중 가장 가까운 회의 조회
+        Meeting futureMeeting = queryFactory
+                .selectFrom(meeting)
+                .where(meeting.id.in(meetingIds)
+                        .and(meeting.scheduledTime.scheduledStartTime.gt(now)))
+                .orderBy(meeting.scheduledTime.scheduledStartTime.asc())
+                .limit(1)
+                .fetchOne();
+
+        if (futureMeeting != null) {
+            return Optional.of(futureMeeting);
+        }
+
+        // 2. 지난 회의 중 가장 최근 회의 조회
+        Meeting pastMeeting = queryFactory
+                .selectFrom(meeting)
+                .where(meeting.id.in(meetingIds)
+                        .and(meeting.scheduledTime.scheduledStartTime.loe(now)))
+                .orderBy(meeting.scheduledTime.scheduledStartTime.desc())
+                .limit(1)
+                .fetchOne();
+
+        return Optional.ofNullable(pastMeeting);
+    }
+
+    @Override
+    public Optional<MeetingFolder> findByIdWithMeetings(Long folderId) {
+        MeetingFolder folder = queryFactory
+                .selectFrom(meetingFolder)
+                .leftJoin(meetingFolder.meetings, meetingFolderMeeting).fetchJoin()
+                .where(meetingFolder.id.eq(folderId))
+                .fetchOne();
+
+        return Optional.ofNullable(folder);
+    }
+}
+
+

--- a/src/main/java/com/jolupbisang/demo/presentation/meetingFolder/MeetingFolderCreationController.java
+++ b/src/main/java/com/jolupbisang/demo/presentation/meetingFolder/MeetingFolderCreationController.java
@@ -1,0 +1,33 @@
+package com.jolupbisang.demo.presentation.meetingFolder;
+
+import com.jolupbisang.demo.application.meetingFolder.command.MeetingFolderCreationService;
+import com.jolupbisang.demo.application.meetingFolder.command.dto.MeetingFolderCreationReq;
+import com.jolupbisang.demo.application.meetingFolder.command.dto.MeetingFolderCreationRes;
+import com.jolupbisang.demo.infrastructure.auth.security.CustomUserDetails;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class MeetingFolderCreationController {
+
+    private final MeetingFolderCreationService meetingFolderCreationService;
+
+    @PostMapping("/api/v1/meeting-folders")
+    public ResponseEntity<MeetingFolderCreationRes> createFolder(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Valid @RequestBody MeetingFolderCreationReq req) {
+        MeetingFolderCreationRes res = meetingFolderCreationService.create(userDetails.getUserId(), req);
+
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(res);
+    }
+}
+

--- a/src/main/java/com/jolupbisang/demo/presentation/meetingFolder/MeetingFolderDeletionController.java
+++ b/src/main/java/com/jolupbisang/demo/presentation/meetingFolder/MeetingFolderDeletionController.java
@@ -1,0 +1,33 @@
+package com.jolupbisang.demo.presentation.meetingFolder;
+
+import com.jolupbisang.demo.application.meetingFolder.command.MeetingFolderDeletionService;
+import com.jolupbisang.demo.application.meetingFolder.command.dto.MeetingFolderDeletionReq;
+import com.jolupbisang.demo.application.meetingFolder.command.dto.MeetingFolderDeletionRes;
+import com.jolupbisang.demo.infrastructure.auth.security.CustomUserDetails;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class MeetingFolderDeletionController {
+
+    private final MeetingFolderDeletionService meetingFolderDeletionService;
+
+    @DeleteMapping("/api/v1/meeting-folders")
+    public ResponseEntity<MeetingFolderDeletionRes> deleteFolders(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Valid @RequestBody MeetingFolderDeletionReq req) {
+        MeetingFolderDeletionRes res = meetingFolderDeletionService.delete(userDetails.getUserId(), req);
+
+        return ResponseEntity
+                .status(HttpStatus.NO_CONTENT)
+                .body(res);
+    }
+}
+

--- a/src/main/java/com/jolupbisang/demo/presentation/meetingFolder/MeetingFolderDetailQueryController.java
+++ b/src/main/java/com/jolupbisang/demo/presentation/meetingFolder/MeetingFolderDetailQueryController.java
@@ -1,0 +1,27 @@
+package com.jolupbisang.demo.presentation.meetingFolder;
+
+import com.jolupbisang.demo.application.meetingFolder.query.MeetingFolderDetailQueryService;
+import com.jolupbisang.demo.application.meetingFolder.query.dto.MeetingFolderDetailRes;
+import com.jolupbisang.demo.infrastructure.auth.security.CustomUserDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class MeetingFolderDetailQueryController {
+
+    private final MeetingFolderDetailQueryService meetingFolderDetailQueryService;
+
+    @GetMapping("/api/v1/meeting-folders/{folderId}/meetings")
+    public ResponseEntity<MeetingFolderDetailRes> getFolderMeetings(
+            @PathVariable Long folderId,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        MeetingFolderDetailRes res = meetingFolderDetailQueryService.getFolderMeetings(userDetails.getUserId(), folderId);
+        return ResponseEntity.ok(res);
+    }
+}
+

--- a/src/main/java/com/jolupbisang/demo/presentation/meetingFolder/MeetingFolderListQueryController.java
+++ b/src/main/java/com/jolupbisang/demo/presentation/meetingFolder/MeetingFolderListQueryController.java
@@ -1,0 +1,25 @@
+package com.jolupbisang.demo.presentation.meetingFolder;
+
+import com.jolupbisang.demo.application.meetingFolder.query.MeetingFolderListQueryService;
+import com.jolupbisang.demo.application.meetingFolder.query.dto.MeetingFolderListRes;
+import com.jolupbisang.demo.infrastructure.auth.security.CustomUserDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class MeetingFolderListQueryController {
+
+    private final MeetingFolderListQueryService meetingFolderListQueryService;
+
+    @GetMapping("/api/v1/meeting-folders")
+    public ResponseEntity<MeetingFolderListRes> getAllFolders(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        MeetingFolderListRes folders = meetingFolderListQueryService.getFoldersByUserId(userDetails.getUserId());
+        return ResponseEntity
+                .ok(folders);
+    }
+}
+

--- a/src/main/java/com/jolupbisang/demo/presentation/meetingFolder/MeetingFolderUpdateController.java
+++ b/src/main/java/com/jolupbisang/demo/presentation/meetingFolder/MeetingFolderUpdateController.java
@@ -1,0 +1,47 @@
+package com.jolupbisang.demo.presentation.meetingFolder;
+
+import com.jolupbisang.demo.application.meetingFolder.command.MeetingFolderUpdateService;
+import com.jolupbisang.demo.application.meetingFolder.command.dto.MeetingFolderUpdateReq;
+import com.jolupbisang.demo.application.meetingFolder.command.dto.MeetingFolderUpdateRes;
+import com.jolupbisang.demo.infrastructure.auth.security.CustomUserDetails;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class MeetingFolderUpdateController {
+
+    private final MeetingFolderUpdateService meetingFolderUpdateService;
+
+    @PostMapping("/api/v1/meeting-folders/{folderId}/meetings")
+    public ResponseEntity<MeetingFolderUpdateRes> addMeetings(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long folderId,
+            @Valid @RequestBody MeetingFolderUpdateReq req) {
+        MeetingFolderUpdateRes res = meetingFolderUpdateService.addMeetings(userDetails.getUserId(), folderId, req);
+
+        return ResponseEntity
+                .ok(res);
+    }
+
+    @DeleteMapping("/api/v1/meeting-folders/{folderId}/meetings")
+    public ResponseEntity<MeetingFolderUpdateRes> removeMeetings(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long folderId,
+            @Valid @RequestBody MeetingFolderUpdateReq req) {
+        MeetingFolderUpdateRes res = meetingFolderUpdateService.removeMeetings(userDetails.getUserId(), folderId, req);
+
+        return ResponseEntity
+                .status(HttpStatus.NO_CONTENT)
+                .body(res);
+    }
+}
+


### PR DESCRIPTION
## 구현기능
- 회의록 폴더 조회
- 회의록 폴더 생성 (빈 폴더로 기본 생성 - 이름만 받음)
- 회의록 폴더 삭제
- 회의록 펄더의 회의록 추가 (한꺼번에 여러개)
- 회의록 폴더의 회의록 조회 (한꺼번에 여러개)
- 회의록 폴더의 회의록 목록 조회

<img width="659" height="355" alt="image" src="https://github.com/user-attachments/assets/414dee8d-8810-4223-84f8-10f25a74224d" />
