### PR TITLE
fix: 오디오 생성 시 생성 시간 30초 오차 허용

### DIFF
--- a/src/main/java/com/jolupbisang/demo/application/context/service/ContextService.java
+++ b/src/main/java/com/jolupbisang/demo/application/context/service/ContextService.java
@@ -77,7 +77,7 @@ public class ContextService {
 
         ContextResponse.SummaryRes summary = contextResponse.summary();
         if (summary != null && !summary.content().isEmpty()) {
-            log.info("Context received - meetingId: {}, content: {}", meetingId, summary.content());
+            log.info("Summary received - meetingId: {}, content: {}", meetingId, summary.content());
             eventPublisher.publishEvent(new SummaryReceivedEvent(meetingId, summary.content(), summary.ids(), isRecap, LocalDateTime.now()));
         }
 

--- a/src/main/java/com/jolupbisang/demo/domain/audio/model/AudioChunk.java
+++ b/src/main/java/com/jolupbisang/demo/domain/audio/model/AudioChunk.java
@@ -54,9 +54,18 @@ public class AudioChunk {
     }
 
     private void setCreatedDateTime(LocalDateTime createdDateTime) {
+        if (createdDateTime == null) {
+            throw new DomainException(AudioDomainErrorCode.NULL_CREATED_DATE_TIME);
+        }
+        
+        // 클라이언트-서버 간 시계 동기화 차이와 네트워크 지연을 고려하여 ±30초 허용
         LocalDateTime now = LocalDateTime.now();
-        if (createdDateTime == null || createdDateTime.isAfter(now)) {
-            throw new DomainException(AudioDomainErrorCode.FUTURE_CREATED_DATE_TIME, "createdDateTime: %s, now: %s", createdDateTime, now);
+        LocalDateTime minAllowedTime = now.minusSeconds(30);
+        LocalDateTime maxAllowedTime = now.plusSeconds(30);
+        
+        if (createdDateTime.isBefore(minAllowedTime) || createdDateTime.isAfter(maxAllowedTime)) {
+            throw new DomainException(AudioDomainErrorCode.FUTURE_CREATED_DATE_TIME, 
+                "timestamp out of acceptable range. createdDateTime: %s, now: %s", createdDateTime, now);
         }
         this.createdDateTime = createdDateTime;
     }

--- a/src/main/java/com/jolupbisang/demo/domain/audio/model/EmbeddingAudio.java
+++ b/src/main/java/com/jolupbisang/demo/domain/audio/model/EmbeddingAudio.java
@@ -36,9 +36,18 @@ public class EmbeddingAudio {
     }
 
     private void setCreatedDateTime(LocalDateTime createdDateTime) {
+        if (createdDateTime == null) {
+            throw new DomainException(AudioDomainErrorCode.NULL_CREATED_DATE_TIME);
+        }
+        
+        // 클라이언트-서버 간 시계 동기화 차이와 네트워크 지연을 고려하여 ±30초 허용
         LocalDateTime now = LocalDateTime.now();
-        if (createdDateTime == null || createdDateTime.isAfter(now)) {
-            throw new DomainException(AudioDomainErrorCode.FUTURE_CREATED_DATE_TIME, "createdDateTime: %s, now: %s", createdDateTime, now);
+        LocalDateTime minAllowedTime = now.minusSeconds(30);
+        LocalDateTime maxAllowedTime = now.plusSeconds(30);
+        
+        if (createdDateTime.isBefore(minAllowedTime) || createdDateTime.isAfter(maxAllowedTime)) {
+            throw new DomainException(AudioDomainErrorCode.FUTURE_CREATED_DATE_TIME, 
+                "timestamp out of acceptable range. createdDateTime: %s, now: %s", createdDateTime, now);
         }
         this.createdDateTime = createdDateTime;
     }

--- a/src/main/java/com/jolupbisang/demo/infrastructure/sse/MeetingSseManager.java
+++ b/src/main/java/com/jolupbisang/demo/infrastructure/sse/MeetingSseManager.java
@@ -45,7 +45,7 @@ public class MeetingSseManager {
 
     public void sendEvent(long meetingId, long userId, MeetingSseEventType eventType, Object data) {
         if (!meetingEmitters.containsKey(meetingId)) {
-            log.error("해당 회의에 연결된 Sse 클라이언트가 없습니다. meetingId: {}", meetingId);
+            log.error("해당 회의에 연결된 Sse 클라이언트가 없습니다. meetingId: {}, 보내려던 userId {}", meetingId, userId);
             return;
         }
 
@@ -63,12 +63,12 @@ public class MeetingSseManager {
         });
 
         emitter.onTimeout(() -> {
-            log.info("[{}]: meetingId {} SSE connection timed out", emitter, meetingId);
+            log.info("[{}]: meetingId {}, userId {} SSE connection timed out", emitter, meetingId, userId);
             emitter.complete();
         });
 
         emitter.onError((ex) -> {
-            log.info("[{}]: meetingId {} SSE connection error", emitter, meetingId, ex);
+            log.info("[{}]: meetingId {}, userId {} SSE connection error", emitter, meetingId, userId, ex);
             emitter.complete();
         });
 

--- a/src/main/java/com/jolupbisang/demo/presentation/audio/dto/response/SocketResponseType.java
+++ b/src/main/java/com/jolupbisang/demo/presentation/audio/dto/response/SocketResponseType.java
@@ -4,7 +4,6 @@ public enum SocketResponseType {
     ERROR,
     DIARIZED_SEGMENT,
     FEEDBACK,
-    PARTICIPATION_RATE,
     SUMMARY,
     COMPLETION_SCHEDULED,
     MEETING_COMPLETED,


### PR DESCRIPTION
## 구현 기능
- 오디오 생성시 앱의 시간 때문에 오차가 생기는 것을 해결
- 로깅 추가