### PR TITLE
fix: 오디오 청크 30초 오차 허용 로직 추가

### DIFF
--- a/src/main/java/com/jolupbisang/demo/domain/audio/model/AudioChunk.java
+++ b/src/main/java/com/jolupbisang/demo/domain/audio/model/AudioChunk.java
@@ -54,9 +54,18 @@ public class AudioChunk {
     }
 
     private void setCreatedDateTime(LocalDateTime createdDateTime) {
+        if (createdDateTime == null) {
+            throw new DomainException(AudioDomainErrorCode.NULL_CREATED_DATE_TIME);
+        }
+        
+        // 클라이언트-서버 간 시계 동기화 차이와 네트워크 지연을 고려하여 ±30초 허용
         LocalDateTime now = LocalDateTime.now();
-        if (createdDateTime == null || createdDateTime.isAfter(now)) {
-            throw new DomainException(AudioDomainErrorCode.FUTURE_CREATED_DATE_TIME, "createdDateTime: %s, now: %s", createdDateTime, now);
+        LocalDateTime minAllowedTime = now.minusSeconds(30);
+        LocalDateTime maxAllowedTime = now.plusSeconds(30);
+        
+        if (createdDateTime.isBefore(minAllowedTime) || createdDateTime.isAfter(maxAllowedTime)) {
+            throw new DomainException(AudioDomainErrorCode.FUTURE_CREATED_DATE_TIME, 
+                "timestamp out of acceptable range. createdDateTime: %s, now: %s", createdDateTime, now);
         }
         this.createdDateTime = createdDateTime;
     }


### PR DESCRIPTION
## 구현기능
-  오디오 청크 30초 오차 허용 로직 추가